### PR TITLE
fix: remove unused BUILD_PLATFORM variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ CONTAINER_NAME   ?= claude-code-env
 # Explicit --platform prevents accidental amd64 builds that would require Rosetta.
 PLATFORM_macos   := linux/arm64
 PLATFORM_wsl2    := linux/amd64
-BUILD_PLATFORM    = $(PLATFORM_$(_OS))
 
 # Detect OS once; used by all targets that branch per platform
 # $(shell ...) is used instead of != for compatibility with GNU Make 3.81 (ships with macOS)


### PR DESCRIPTION
## Summary

- `BUILD_PLATFORM` was defined but never used — all build targets reference `PLATFORM_macos` and `PLATFORM_wsl2` directly
- Discovered while using this template in a downstream repo

## Test plan
- [ ] `make build` still works on macOS (uses `PLATFORM_macos`)
- [ ] `make build` still works on WSL2 (uses `PLATFORM_wsl2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)