### PR TITLE
feat: add AI template layer, self-improvement loop, and sandbox model

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md — Project Intelligence for Claude Code
+
+## What This Repo Is
+
+This is a **GitHub template repository** that provides an isolated, cross-platform container environment for running Claude Code. It supports macOS (Apple Virtualization.framework via `apple/container`) and Windows WSL2 (rootless Podman). Nested containers are supported inside the devcontainer for sandboxed workloads.
+
+When someone instantiates this template, they get a ready-to-use Claude Code development environment with credential forwarding, nested container support, and cross-platform tooling.
+
+## Architecture Decisions (Do Not Change Without Discussion)
+
+1. **Dual runtime model**: macOS uses `apple/container` (attach model), WSL2 uses Podman (reopen-in-container model). These are fundamentally different lifecycle models — do not try to unify them into one path.
+2. **Credential forwarding via `/run/host-secrets/`**: Host credentials are mounted read-only, then copied to writable locations by `postCreateCommand` / `run.sh`. This avoids permission issues with UID mismatches between host and container.
+3. **Nested containers via rootless Podman inside the devcontainer**: The inner Podman uses `fuse-overlayfs`, `slirp4netns`, and `keep-id` user namespace mapping. The subuid/subgid range is 131072 (not 65536) to avoid the triple-mapping overlap bug.
+4. **Ubuntu base image**: Pinned to a specific release in the Containerfile. Podman packages from Ubuntu repos are preferred over upstream to avoid dependency conflicts.
+5. **No Docker dependency**: The entire stack is Docker-free. WSL2 uses Podman natively; macOS uses Apple's container CLI. `DOCKER_HOST` is set to the Podman socket for tool compatibility only.
+
+## Repository Structure
+
+```
+.claude/              → Claude Code configuration and slash commands (this layer)
+.devcontainer/        → Container definition, configs, lifecycle scripts
+.github/              → CI workflows, issue templates
+.vscode/              → Editor settings and extension recommendations
+scripts/              → Platform-specific installers and runtime scripts
+template/             → Template instantiation config and hooks
+tests/                → Container validation checks
+docs/                 → Architecture docs, sandbox model, conventions
+```
+
+## Key Files and Their Roles
+
+- `.devcontainer/Containerfile` — the OCI image definition. Changes here require `make build`.
+- `.devcontainer/devcontainer.json` — VSCode devcontainer config. `runArgs` apply to WSL2 only.
+- `scripts/macos/run.sh` — starts the container on macOS and copies credentials in.
+- `Makefile` — primary interface: `build`, `run`, `stop`, `status`, `clean`.
+- `tests/container-checks.sh` — validates the container environment. Run in CI and locally.
+
+## Coding Conventions
+
+- **Shell scripts**: `bash`, `set -euo pipefail`, ShellCheck clean. Use `#!/usr/bin/env bash`.
+- **Comments**: Explain *why*, not *what*. Every non-obvious decision gets a comment.
+- **Makefile**: GNU Make compatible (no `!=` operator — macOS ships Make 3.81).
+- **Container paths**: credentials in `/run/host-secrets/`, workspace at `/workspace`.
+- **No hardcoded usernames**: Use `${USERNAME}` build arg or `$(whoami)` at runtime.
+
+## What Claude Code Should and Should Not Do
+
+### Safe to modify
+- Files under `src/` or `/workspace` (project code in instantiated repos)
+- Documentation in `docs/`
+- Test scripts in `tests/`
+- `.claude/commands/` slash command definitions
+- `.gitignore`, `.editorconfig`
+
+### Modify with care (explain reasoning)
+- `.devcontainer/devcontainer.json` — affects both platforms
+- `.devcontainer/Containerfile` — changes affect image builds
+- `Makefile` — cross-platform build logic
+- `.github/workflows/` — CI pipeline
+
+### Do not modify without explicit human approval
+- `.devcontainer/config/containers.conf` — Podman engine config, security-sensitive
+- `.devcontainer/config/storage.conf` — storage driver config
+- `scripts/macos/run.sh` — macOS container lifecycle
+- `scripts/wsl2/install.sh` — WSL2 system configuration
+- Security-related `runArgs` in `devcontainer.json`
+
+## Self-Improvement Guidelines
+
+When asked to improve the repo (via `/improve-repo` or similar):
+1. Always propose changes as a diff or branch — never commit directly to main.
+2. Check the CI workflow passes conceptually before proposing changes.
+3. Cross-platform impact: if a change affects one platform, verify it doesn't break the other.
+4. Update `docs/ARCHITECTURE.md` if architectural decisions change.
+5. Update this `CLAUDE.md` if conventions or structure change.
+6. Prefer additive changes over modifications to working code.
+
+## Template Variables
+
+When this repo is used as a template, the following can be customised:
+- Project name (replaces `claude-code-container` references)
+- Additional Containerfile packages
+- VSCode extensions
+- Forwarded ports
+- Claude Code permission scope
+
+See `template/template.json` for the full variable schema.

--- a/.claude/commands/add-toolchain.md
+++ b/.claude/commands/add-toolchain.md
@@ -1,0 +1,32 @@
+# /add-toolchain
+
+Add a new language or tool to the container environment.
+
+## Gather Information
+
+Ask the user:
+1. What tool or language to add (e.g., Python 3.12, Rust, Go, Java, .NET)
+2. Whether it should be in the base image or installed at runtime
+
+## Actions
+
+1. **Add to Containerfile**: Insert a new clearly-commented section after the Node.js block. Follow the existing pattern:
+   - Dedicated `RUN` layer with section header comment
+   - Clean apt caches in the same layer
+   - Pin versions where possible
+
+2. **Add VS Code extensions**: Add relevant language extensions to `.devcontainer/devcontainer.json`
+
+3. **Update tests**: Add toolchain presence checks to `tests/container-checks.sh`
+
+4. **Update documentation**:
+   - Add to the "Customising the environment" section in `README.md`
+   - Update `CLAUDE.md` if conventions change
+
+5. **Verify cross-platform**: Ensure the packages are available on both `linux/arm64` (macOS) and `linux/amd64` (WSL2) architectures.
+
+## Do NOT
+
+- Remove existing tools unless asked
+- Change the base image
+- Modify Podman or nested container configuration

--- a/.claude/commands/audit-security.md
+++ b/.claude/commands/audit-security.md
@@ -1,0 +1,36 @@
+# /audit-security
+
+Perform a security audit of the container environment and configuration.
+
+## Check These Areas
+
+1. **Container permissions**
+   - Review `runArgs` in `devcontainer.json` — are `seccomp=unconfined` and `apparmor=unconfined` still required? Can they be narrowed?
+   - Review `default_capabilities` in `containers.conf` — is each capability justified?
+   - Is `SYS_PTRACE` still needed? Under what conditions?
+
+2. **Credential handling**
+   - Are credentials ever written to image layers? (`docker history` / build cache check)
+   - Are `/run/host-secrets/` permissions correct (readable only by container user)?
+   - Does `postCreateCommand` clean up intermediate credential state?
+   - Is `.claude.json` writable in the container? (It needs to be for token refresh.)
+
+3. **Nested container isolation**
+   - What can a nested container access on the host?
+   - Can a nested container escape to the outer container's namespace?
+   - Are subuid/subgid ranges non-overlapping with real host users?
+
+4. **Network exposure**
+   - What ports are forwarded by default?
+   - Can Claude Code open arbitrary ports?
+   - Is `slirp4netns` properly isolating nested container network access?
+
+5. **Supply chain**
+   - Are base images from trusted registries?
+   - Is the NodeSource script fetched over HTTPS with integrity checking?
+   - Are GitHub CLI GPG keys verified?
+
+## Output
+
+Classify each finding as: CRITICAL / HIGH / MEDIUM / LOW / INFO.
+For CRITICAL and HIGH findings, include a remediation with a code diff.

--- a/.claude/commands/improve-repo.md
+++ b/.claude/commands/improve-repo.md
@@ -1,0 +1,48 @@
+# /improve-repo
+
+Audit the repository and propose improvements. Follow this checklist:
+
+## Audit Steps
+
+1. **Containerfile health**
+   - Is the base image pinned to a specific version? Flag if using `latest`.
+   - Are there any packages that could be consolidated into fewer RUN layers?
+   - Is Claude Code version pinned or using `latest`? Note the trade-off.
+   - Are there any known CVEs in the base image packages?
+
+2. **Devcontainer config**
+   - Are all mounts still necessary?
+   - Are `runArgs` minimal (principle of least privilege)?
+   - Are forwarded ports documented?
+   - Does `postCreateCommand` handle all credential scenarios gracefully?
+
+3. **Cross-platform parity**
+   - Does the macOS `run.sh` handle the same credential mounts as `devcontainer.json`?
+   - Are there features available on one platform but not the other? Document gaps.
+
+4. **CI pipeline**
+   - Does the CI workflow test everything that `container-checks.sh` covers?
+   - Are there untested paths (macOS-specific logic can't run in CI — is this documented)?
+
+5. **Documentation**
+   - Is `README.md` current with actual repo structure?
+   - Is `CLAUDE.md` consistent with the actual codebase?
+   - Is `docs/ARCHITECTURE.md` up to date?
+
+6. **Template health**
+   - Does `template/template.json` cover all customisable variables?
+   - Does the init script work for a fresh instantiation?
+
+7. **Security**
+   - Are credentials never baked into the image?
+   - Is `/run/host-secrets/` properly cleaned after copy?
+   - Are subuid/subgid ranges adequate?
+
+## Output
+
+For each finding, propose a fix as a code change with explanation. Group changes into:
+- **Critical** — security or correctness issues
+- **Recommended** — quality-of-life or robustness improvements
+- **Nice-to-have** — cosmetic or documentation tweaks
+
+Create a new branch `improve/YYYY-MM-DD` with the changes, but do NOT push without human review.

--- a/.claude/commands/init-project.md
+++ b/.claude/commands/init-project.md
@@ -1,0 +1,44 @@
+# /init-project
+
+Customise this repository after it has been instantiated from the template.
+
+## Gather Information
+
+Ask the user for:
+1. **Project name** — used in README, container name, Makefile variables
+2. **Primary language/runtime** — determines additional Containerfile packages
+3. **Additional VS Code extensions** — beyond the defaults
+4. **Forwarded ports** — any ports the project needs exposed
+5. **Additional system packages** — anything to add to the Containerfile
+
+## Actions
+
+1. Update `README.md`:
+   - Replace template references with project name
+   - Add project-specific setup instructions
+   - Remove the "Using this template" section
+
+2. Update `.devcontainer/devcontainer.json`:
+   - Set `name` to project name
+   - Add requested extensions to `customizations.vscode.extensions`
+   - Add requested ports to `forwardPorts`
+
+3. Update `Makefile`:
+   - Set `IMAGE_TAG` default to `<project-name>:latest`
+   - Set `CONTAINER_NAME` default to `<project-name>-env`
+
+4. Update `.devcontainer/Containerfile` (if additional packages requested):
+   - Add packages to the appropriate `RUN apt-get install` layer
+   - Add language-specific setup (e.g., Python venv, Rust toolchain)
+
+5. Update `CLAUDE.md`:
+   - Add project-specific context
+   - Update conventions for the chosen language
+
+6. Create initial `src/` structure appropriate for the language.
+
+7. Remove `template/` directory (no longer needed after instantiation).
+
+## Commit
+
+Stage all changes and create a commit: `chore: initialise <project-name> from claude-code-container template`

--- a/.claude/commands/update-deps.md
+++ b/.claude/commands/update-deps.md
@@ -1,0 +1,25 @@
+# /update-deps
+
+Check for and propose dependency updates across the container stack.
+
+## What to Check
+
+1. **Base image**: Is there a newer Ubuntu LTS or point release?
+2. **Node.js**: Is the NodeSource setup script pulling the latest LTS?
+3. **Claude Code**: Check the latest `@anthropic-ai/claude-code` version on npm.
+4. **Podman**: Is the Ubuntu-packaged version current? Are there important fixes in newer versions?
+5. **GitHub CLI**: Check latest `gh` release.
+6. **zsh-in-docker**: Check the `ZSH_IN_DOCKER_VERSION` ARG against releases.
+7. **GitHub Actions**: Are `actions/checkout` and other actions on latest major versions?
+
+## Rules
+
+- Only propose LTS or stable versions, never pre-release.
+- For the base image, prefer point releases over `latest` tags.
+- Note any breaking changes between current and proposed versions.
+- If a dependency update changes behaviour, update tests and documentation.
+
+## Output
+
+Present a table: | Dependency | Current | Latest | Breaking Changes | Recommendation |
+Then provide the Containerfile diff for approved updates.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/settings-schema.json",
+  "permissions": {
+    "allow": [
+      "Read any file in the repository",
+      "Edit files under src/, docs/, tests/, .claude/commands/",
+      "Run make build, make status, make clean",
+      "Run tests/container-checks.sh",
+      "Run git status, git diff, git log, git branch",
+      "Create new files in src/, docs/, tests/",
+      "Run npm install, npm test, pip install"
+    ],
+    "deny": [
+      "Never modify .devcontainer/config/ without explicit approval",
+      "Never run make run or container run (host-side operation)",
+      "Never modify scripts/macos/ or scripts/wsl2/ without explicit approval",
+      "Never push to main branch directly",
+      "Never delete files outside of src/",
+      "Never modify CI workflows without explicit approval",
+      "Never access or modify /run/host-secrets/ contents",
+      "Never run sudo commands without explicit approval"
+    ]
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+indent_size = 2

--- a/.github/ISSUE_TEMPLATE/claude-improvement.md
+++ b/.github/ISSUE_TEMPLATE/claude-improvement.md
@@ -1,0 +1,39 @@
+---
+name: Claude Code Improvement
+about: Improvement proposed by Claude Code via /improve-repo or /audit-security
+title: "[AI] "
+labels: ["ai-proposed", "needs-review"]
+---
+
+## Source
+
+- [ ] `/improve-repo` audit
+- [ ] `/audit-security` audit
+- [ ] `/update-deps` check
+- [ ] Other: ___
+
+## Severity
+
+- [ ] Critical (security or correctness)
+- [ ] Recommended (robustness or quality)
+- [ ] Nice-to-have (cosmetic or documentation)
+
+## Description
+
+<!-- What was found and why it matters -->
+
+## Proposed Change
+
+```diff
+<!-- Include the diff here -->
+```
+
+## Impact
+
+- **Platforms affected**: macOS / WSL2 / Both
+- **Breaking change**: Yes / No
+- **Requires rebuild**: Yes / No
+
+## Verification
+
+<!-- How to verify the fix works -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,48 @@
+# macOS
 .DS_Store
+._*
+
+# Editors
+*.swp
+*.swo
+*~
+.idea/
+*.iml
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# Build artifacts
+*.o
+*.so
+*.dylib
+dist/
+build/
+out/
+
+# Environment and secrets
+.env
+.env.local
+.env.*.local
+*.pem
+*.key
+
+# Container artifacts
+*.tar
+*.oci
+
+# Backup files from sed/template init
+*.bak
+
+# Claude Code local state (auth is on host, not in repo)
+.claude.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,75 @@
+# Architecture
+
+## Overview
+
+This repository provides a containerised development environment for Claude Code that works identically on macOS (Apple Silicon) and Windows (WSL2). The design prioritises isolation, portability, and the ability for Claude Code to spawn nested containers for sandboxed workloads.
+
+## Design Principles
+
+1. **No Docker**: The stack is entirely Docker-free. This avoids Docker Desktop licensing, reduces resource overhead, and leverages platform-native virtualisation.
+2. **Platform-native runtimes**: macOS uses Apple's `container` CLI (Virtualization.framework); WSL2 uses Podman (rootless, daemonless). These are the lightest-weight options for each platform.
+3. **Single image, two lifecycles**: Both platforms build the same OCI image from the same Containerfile. The difference is how the container is started and how VS Code connects to it.
+4. **Credentials stay on the host**: Authentication tokens are never baked into the image. They're mounted read-only at runtime and copied into writable locations inside the container.
+5. **Nested containers without privilege escalation**: Inner Podman runs rootless with user namespace remapping. No `--privileged` flag is used outside of CI.
+
+## Runtime Models
+
+### macOS (Attach Model)
+
+```
+Host (macOS)
+  └── apple/container VM (Virtualization.framework)
+       └── Ubuntu container (our Containerfile)
+            ├── Claude Code (Node.js)
+            └── Podman (rootless) → nested containers
+```
+
+The container is a lightweight Linux VM. `make run` starts it; VS Code attaches to the running container. The `postCreateCommand` in `devcontainer.json` does NOT run in this model — credential setup is handled by `scripts/macos/run.sh`.
+
+### WSL2 (Reopen Model)
+
+```
+Host (Windows)
+  └── WSL2 (Linux kernel)
+       └── Podman (rootless, via socket)
+            └── Ubuntu container (our Containerfile)
+                 ├── Claude Code (Node.js)
+                 └── Podman (rootless) → nested containers
+```
+
+VS Code uses the Dev Containers extension to build and start the container via the Podman socket. The `postCreateCommand` runs automatically after container creation.
+
+## Credential Flow
+
+```
+Host credentials (read-only)
+  ~/.claude.json        → /run/host-secrets/claude.json    → copied to ~/.claude.json (rw)
+  ~/.claude/            → /run/host-secrets/claude-dir/    → selective copy to ~/.claude/
+  ~/.gitconfig          → /run/host-secrets/gitconfig      → copied to ~/.gitconfig
+  ~/.config/gh/         → /home/claude/.config/gh/ (direct mount, ro)
+```
+
+The `/run/host-secrets/` staging area exists because direct bind mounts of individual files have portability issues across container runtimes (UID mapping, filesystem notifications). The copy-on-create pattern is more reliable.
+
+## Nested Container Architecture
+
+The inner Podman is configured for rootless operation inside an already-namespaced environment:
+
+- **User namespace**: `keep-id` mapping avoids double-remapping conflicts
+- **Storage**: `fuse-overlayfs` (kernel overlay not available in user namespaces)
+- **Network**: `slirp4netns` (doesn't require `/dev/net/tun` access)
+- **Cgroup**: `cgroupfs` manager (no systemd inside the container)
+- **subuid/subgid**: 131072 range to avoid the triple-mapping overlap bug
+
+## Security Model
+
+See [SANDBOX-MODEL.md](SANDBOX-MODEL.md) for the full isolation and threat model.
+
+## Template System
+
+This repo serves as a GitHub Template Repository. After instantiation:
+
+1. The `/init-project` Claude Code slash command customises names, packages, and extensions.
+2. `template/template.json` defines the variable schema.
+3. `template/hooks/post-init.sh` performs the substitutions.
+4. The `template/` directory can be removed after initialisation.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,43 @@
+# Conventions
+
+## Shell Scripts
+
+- Shebang: `#!/usr/bin/env bash`
+- Always set: `set -euo pipefail`
+- Quote all variable expansions: `"${VAR}"` not `$VAR`
+- Use `[[ ]]` for conditionals, not `[ ]`
+- Functions use lowercase with underscores: `_detect_os()`
+- Exit with meaningful codes: 0 = success, 1 = user error, 2 = system error
+- Log with `echo "==> Action..."` for top-level steps, `echo "    Detail..."` for sub-steps
+
+## Makefile
+
+- Compatible with GNU Make 3.81 (ships with macOS)
+- No `:=` or `!=` operators — use `$(shell ...)` instead
+- Targets are `.PHONY` unless they produce files
+- Help target uses `grep -E '^## '` convention
+- Variables at the top with `?=` for overridability
+
+## Containerfile
+
+- One concern per `RUN` layer (readability over layer count)
+- Pin base image to a specific release, not `latest`
+- Clean apt caches in the same `RUN` that installs: `&& rm -rf /var/lib/apt/lists/*`
+- Use build args for anything that might change between builds
+- Comments explain *why* each section exists
+
+## Documentation
+
+- Use Australian English spelling (behaviour, customise, initialise)
+- Markdown files use ATX headings (`#` not underlines)
+- Code blocks specify the language for syntax highlighting
+- Keep lines under 100 characters where practical
+- README covers *usage*; ARCHITECTURE covers *design*; this file covers *style*
+
+## Git
+
+- Commit messages: `type: short description` (e.g., `fix: handle missing .claude.json`)
+- Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`
+- One logical change per commit
+- Never force-push to `main`
+- PRs require CI to pass

--- a/docs/SANDBOX-MODEL.md
+++ b/docs/SANDBOX-MODEL.md
@@ -1,0 +1,78 @@
+# Sandbox Model
+
+## Purpose
+
+This document describes the isolation boundaries for the Claude Code container environment. Because Claude Code operates with a higher degree of automation than typical developer tools, the sandbox model is designed to limit blast radius if something goes wrong.
+
+## Trust Boundaries
+
+```
+┌─────────────────────────────────────────────────┐
+│ Host machine (fully trusted)                    │
+│  ├── Host filesystem (not accessible)           │
+│  ├── Host network (accessible via NAT)          │
+│  └── Credential files (read-only mount)         │
+├─────────────────────────────────────────────────┤
+│ Outer container (semi-trusted)                  │
+│  ├── /workspace (read-write, project files)     │
+│  ├── Claude Code (Node.js process)              │
+│  ├── Git operations (within /workspace)         │
+│  └── Podman (rootless, nested containers)       │
+├─────────────────────────────────────────────────┤
+│ Inner containers (untrusted workloads)          │
+│  ├── User-namespaced (no real root)             │
+│  ├── Network via slirp4netns (isolated)         │
+│  └── Storage via fuse-overlayfs (isolated)      │
+└─────────────────────────────────────────────────┘
+```
+
+## What the Container CAN Do
+
+- Read and write files under `/workspace`
+- Execute Claude Code and any tools it invokes
+- Spawn nested containers via rootless Podman
+- Access the network (outbound, via NAT / slirp4netns)
+- Read host credentials (Claude auth, git config, GitHub CLI)
+- Install packages via apt, npm, pip (inside the container)
+
+## What the Container CANNOT Do
+
+- Access host filesystem outside of explicitly mounted paths
+- Modify host credentials (mounted read-only)
+- Run privileged operations (no `--privileged`, rootless Podman)
+- Access other containers or VMs on the host
+- Survive a container stop/rebuild (ephemeral by design)
+- Access host Docker/Podman daemon (no socket mount)
+
+## Risk Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Claude Code modifies critical config | `.claude/settings.json` deny list; CLAUDE.md conventions |
+| Credential exfiltration | Read-only mounts; credentials are API tokens, not passwords |
+| Nested container escape | User namespace isolation; no `--privileged` flag |
+| Supply chain attack via Containerfile | Pinned base images; HTTPS-only package sources; GPG-verified repos |
+| Runaway resource usage | macOS: VM resource limits in `run.sh`; WSL2: Podman cgroup limits |
+| Persistent malware | Container is ephemeral; `make clean` removes the image entirely |
+
+## Credential Lifecycle
+
+1. Host credentials are created by the user (e.g., `claude login`, `gh auth login`)
+2. At container start, credentials are mounted read-only into `/run/host-secrets/`
+3. `postCreateCommand` / `run.sh` copies them to writable locations
+4. Claude Code uses the writable copies (it needs write access for token refresh)
+5. On container stop, writable copies are destroyed (container is ephemeral)
+6. Token refresh writes go to the container-local copy, NOT back to the host
+
+**Implication**: If Claude Code refreshes its auth token inside the container, the refreshed token is lost on container restart. The user may need to re-authenticate. This is a deliberate trade-off for security.
+
+## Extending the Sandbox
+
+When adding new capabilities to the container:
+
+1. Document what new access is required and why
+2. Prefer read-only mounts over read-write
+3. Prefer copying credentials over direct mounts
+4. Update `.claude/settings.json` if new paths should be protected
+5. Update `tests/container-checks.sh` to validate the new configuration
+6. Update this document

--- a/scripts/init-from-template.sh
+++ b/scripts/init-from-template.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Instantiate a new project from this template.
+# This is the non-Claude-Code path — for users who want to script it.
+#
+# Usage:
+#   bash scripts/init-from-template.sh my-project
+#
+# For interactive customisation, use the /init-project Claude Code command instead.
+set -euo pipefail
+
+PROJECT_NAME="${1:-}"
+
+if [[ -z "${PROJECT_NAME}" ]]; then
+  echo "Usage: bash scripts/init-from-template.sh <project-name>"
+  echo ""
+  echo "  project-name    Lowercase, hyphenated name (e.g. my-api-service)"
+  echo ""
+  echo "For interactive setup with Claude Code, use the /init-project command instead."
+  exit 1
+fi
+
+# Validate project name
+if [[ ! "${PROJECT_NAME}" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  echo "error: project name must be lowercase alphanumeric with hyphens (e.g. my-project)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Run the post-init hook
+bash "${REPO_ROOT}/template/hooks/post-init.sh" "${PROJECT_NAME}"
+
+echo ""
+echo "You can now remove the template/ directory:"
+echo "  rm -rf template/"
+echo "  git add -A && git commit -m 'chore: initialise ${PROJECT_NAME} from template'"

--- a/template/hooks/post-init.sh
+++ b/template/hooks/post-init.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Runs after template instantiation to apply variable substitutions.
+# Called by: scripts/init-from-template.sh or the /init-project slash command.
+set -euo pipefail
+
+PROJECT_NAME="${1:?Usage: post-init.sh <project-name>}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "==> Initialising '${PROJECT_NAME}' from template..."
+
+# ── Makefile ──────────────────────────────────────────────────────────────────
+sed -i.bak \
+  -e "s|IMAGE_TAG        ?= claude-code-devcontainer:latest|IMAGE_TAG        ?= ${PROJECT_NAME}:latest|" \
+  -e "s|CONTAINER_NAME   ?= claude-code-env|CONTAINER_NAME   ?= ${PROJECT_NAME}-env|" \
+  "${REPO_ROOT}/Makefile"
+
+# ── devcontainer.json ─────────────────────────────────────────────────────────
+# Use python for JSON manipulation to preserve comments (jq strips them)
+python3 -c "
+import json, sys
+path = '${REPO_ROOT}/.devcontainer/devcontainer.json'
+# Read raw to preserve structure, do simple string replace for the name field
+with open(path) as f:
+    content = f.read()
+content = content.replace('\"Claude Code\"', '\"${PROJECT_NAME}\"', 1)
+with open(path, 'w') as f:
+    f.write(content)
+print('    Updated devcontainer.json name')
+"
+
+# ── Clean up ──────────────────────────────────────────────────────────────────
+rm -f "${REPO_ROOT}/Makefile.bak"
+
+# Create src/ directory
+mkdir -p "${REPO_ROOT}/src"
+echo "# ${PROJECT_NAME}" > "${REPO_ROOT}/src/.gitkeep"
+
+echo ""
+echo "Template initialised for '${PROJECT_NAME}'."
+echo "Next steps:"
+echo "  1. Update README.md with project-specific documentation"
+echo "  2. Run 'make build' to build the container image"
+echo "  3. Remove the template/ directory when satisfied"

--- a/template/template.json
+++ b/template/template.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "name": "claude-code-container",
+  "description": "Isolated, cross-platform Claude Code development container",
+  "version": "1.0.0",
+  "variables": {
+    "project_name": {
+      "description": "Name of the project (used in container name, image tag, README)",
+      "type": "string",
+      "default": "my-project",
+      "pattern": "^[a-z][a-z0-9-]*$"
+    },
+    "primary_language": {
+      "description": "Primary programming language/runtime",
+      "type": "string",
+      "enum": ["node", "python", "rust", "go", "java", "dotnet", "none"],
+      "default": "node"
+    },
+    "extra_packages": {
+      "description": "Additional apt packages to install in the container",
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "vscode_extensions": {
+      "description": "Additional VS Code extension IDs",
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "forwarded_ports": {
+      "description": "Ports to forward from the container",
+      "type": "array",
+      "items": { "type": "integer" },
+      "default": []
+    },
+    "claude_code_version": {
+      "description": "Claude Code npm version (use 'latest' for most recent)",
+      "type": "string",
+      "default": "latest"
+    }
+  },
+  "files_to_update": [
+    "README.md",
+    "Makefile",
+    ".devcontainer/devcontainer.json",
+    ".devcontainer/Containerfile",
+    ".claude/CLAUDE.md"
+  ],
+  "post_init": "template/hooks/post-init.sh"
+}


### PR DESCRIPTION
Adds .claude/ (CLAUDE.md, settings, 5 slash commands), template/ (variable schema, init hooks), docs/ (architecture, sandbox model, conventions), .editorconfig, expanded .gitignore, and GitHub issue template for AI-proposed improvements. 16 new files, 728 lines.