### PR TITLE
fix: copy .credentials.json into container and add caps for nested containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,10 @@
     "--security-opt", "seccomp=unconfined",
     "--security-opt", "apparmor=unconfined",
     "--device", "/dev/fuse",
-    "--cap-add", "SYS_PTRACE"
+    "--device", "/dev/net/tun",
+    "--cap-add", "SYS_PTRACE",
+    "--cap-add", "SETUID",
+    "--cap-add", "SETGID"
   ],
 
   "remoteUser": "claude",
@@ -52,7 +55,7 @@
   // credentials don't exist yet on the host machine.
   "initializeCommand": "bash -c '[ -f \"${HOME}/.claude.json\" ] || echo \"{}\" > \"${HOME}/.claude.json\"; [ -d \"${HOME}/.claude\" ] || mkdir -p \"${HOME}/.claude\"; [ -d \"${HOME}/.config/gh\" ] || mkdir -p \"${HOME}/.config/gh\"; [ -f \"${HOME}/.gitconfig\" ] || touch \"${HOME}/.gitconfig\"'",
 
-  "postCreateCommand": "bash -c 'if [ -f /run/host-secrets/claude.json ]; then cp /run/host-secrets/claude.json $HOME/.claude.json && chmod 600 $HOME/.claude.json; fi; if [ -d /run/host-secrets/claude-dir ]; then for f in settings.json; do [ -f /run/host-secrets/claude-dir/$f ] && cp /run/host-secrets/claude-dir/$f $HOME/.claude/$f; done; [ -d /run/host-secrets/claude-dir/sessions ] && cp -r /run/host-secrets/claude-dir/sessions $HOME/.claude/; fi; if [ -f /run/host-secrets/gitconfig ]; then cp /run/host-secrets/gitconfig $HOME/.gitconfig && chmod 644 $HOME/.gitconfig; fi; bash $HOME/.devcontainer/post-create.sh'",
+  "postCreateCommand": "bash -c 'if [ -f /run/host-secrets/claude.json ]; then cp /run/host-secrets/claude.json $HOME/.claude.json && chmod 600 $HOME/.claude.json; fi; if [ -d /run/host-secrets/claude-dir ]; then for f in settings.json .credentials.json; do [ -f /run/host-secrets/claude-dir/$f ] && cp /run/host-secrets/claude-dir/$f $HOME/.claude/$f && chmod 600 $HOME/.claude/$f; done; [ -d /run/host-secrets/claude-dir/sessions ] && cp -r /run/host-secrets/claude-dir/sessions $HOME/.claude/; fi; if [ -f /run/host-secrets/gitconfig ]; then cp /run/host-secrets/gitconfig $HOME/.gitconfig && chmod 644 $HOME/.gitconfig; fi; bash $HOME/.devcontainer/post-create.sh'",
 
   // Mount host Claude credentials so Claude Code is already authenticated.
   // Individual files are staged into /run/host-secrets/ (directory mount, more

--- a/scripts/macos/run.sh
+++ b/scripts/macos/run.sh
@@ -63,10 +63,11 @@ container exec "${CONTAINER_NAME}" bash -c '
     echo "    Copied ~/.claude.json"
   fi
   if [ -d /run/host-secrets/claude-dir ]; then
-    for f in settings.json; do
+    for f in settings.json .credentials.json; do
       if [ -f "/run/host-secrets/claude-dir/$f" ]; then
         sudo cp "/run/host-secrets/claude-dir/$f" "/home/claude/.claude/$f"
         sudo chown claude:claude "/home/claude/.claude/$f"
+        sudo chmod 600 "/home/claude/.claude/$f"
         echo "    Copied ~/.claude/$f"
       fi
     done


### PR DESCRIPTION
## Summary

- **Credentials fix**: Add `.credentials.json` to the credential copy loop in both `postCreateCommand` (WSL2) and `run.sh` (macOS). This file contains Claude Code auth tokens and was being skipped — only `settings.json` and `sessions/` were copied.
- **Nested container fix**: Add `--device /dev/net/tun` (needed by `slirp4netns` networking) and `SETUID`/`SETGID` capabilities (needed by `newuidmap`/`newgidmap` for user namespace creation) to `runArgs` in `devcontainer.json`.
- Set `chmod 600` on all copied credential files for consistency.

## Test plan

- [ ] Rebuild container on WSL2 — verify `post-create.sh` smoke test passes ("OK — nested containers operational")
- [ ] After container starts, verify `~/.claude/.credentials.json` exists inside the container with correct permissions
- [ ] Run `claude` inside the container and confirm it authenticates without requiring `claude login`
- [ ] Run `podman run --rm alpine echo ok` inside the container to confirm nested containers work

🤖 Generated with [Claude Code](https://claude.com/claude-code)