### PR TITLE
fix: symlink claude to /usr/local/bin so VS Code extension finds it

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -105,7 +105,8 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 # SHA-256 checksum, and runs `claude install` to set up the launcher.
 # PATH is set before install so the script doesn't warn about ~/.local/bin.
 ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
-RUN curl -fsSL https://claude.ai/install.sh | bash
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+    && sudo ln -sf "/home/${USERNAME}/.local/bin/claude" /usr/local/bin/claude
 
 # ── Rootless Podman configuration ─────────────────────────────────────────────
 RUN mkdir -p \


### PR DESCRIPTION
## Summary

The VS Code server process spawns outside of a login shell and gets a minimal PATH that doesn't include `~/.local/bin`. The `anthropic.claude-code` extension was failing with:

> ReferenceError: Claude Code native binary not found at ~/.local/bin/claude

Fix: create a symlink from `/usr/local/bin/claude` → `~/.local/bin/claude` during image build. `/usr/local/bin` is present in all process PAths, including the VS Code server.

## Test plan

- [ ] Rebuild container and open VS Code — extension loads without the path error
- [ ] `which claude` inside the container returns `/usr/local/bin/claude` (symlink) or `~/.local/bin/claude`
- [ ] `claude --version` works from both the terminal and the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)