### PR TITLE
fix: symlink workspace .claude/ config into ~/.claude/ at container start

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -5,23 +5,35 @@ set -euo pipefail
 echo "==> Initialising container environment..."
 # Note: credentials are copied by postCreateCommand before this script runs.
 
-# ── Portable memory: symlink Claude Code's runtime memory to the workspace ───
-# Claude Code writes project memory to ~/.claude/projects/<path-hash>/memory/.
-# By symlinking that path to /workspace/.claude/memory/, memory files land in
-# the git workspace and travel with the repo — portable across machines.
-# Claude Code stores project memory at ~/.claude/projects/<path-with-dashes>/memory/.
-# The workspace is /workspace, so the project dir is "-workspace".
-# Symlink that memory dir into the git workspace so memory files are committed
-# and travel with the repo — portable across machines and container rebuilds.
-WORKSPACE_MEMORY="/workspace/.claude/memory"
+# ── Wire workspace .claude/ config into ~/.claude/ ───────────────────────────
+# Claude Code reads commands, settings, and memory from ~/.claude/ — not from
+# /workspace/.claude/. Symlink each subdirectory so the repo-committed config
+# is the live config, and any writes go back into the workspace.
+
+WORKSPACE_CLAUDE="/workspace/.claude"
+
+# commands/ — slash command definitions live in the repo, symlinked into ~/.claude/
+if [[ -d "${WORKSPACE_CLAUDE}/commands" ]]; then
+  rm -rf "${HOME}/.claude/commands"
+  ln -sfn "${WORKSPACE_CLAUDE}/commands" "${HOME}/.claude/commands"
+  echo "    Linked ~/.claude/commands → workspace (.claude/commands/)"
+fi
+
+# settings.json — repo permissions take precedence over anything copied from host
+if [[ -f "${WORKSPACE_CLAUDE}/settings.json" ]]; then
+  ln -sfn "${WORKSPACE_CLAUDE}/settings.json" "${HOME}/.claude/settings.json"
+  echo "    Linked ~/.claude/settings.json → workspace (.claude/settings.json)"
+fi
+
+# memory/ — symlinked via the project directory so Claude Code's runtime writes
+# land in the workspace and get committed (portable across machines/rebuilds)
 PROJ_DIR="${HOME}/.claude/projects/-workspace"
-if [[ -d "${WORKSPACE_MEMORY}" ]]; then
+if [[ -d "${WORKSPACE_CLAUDE}/memory" ]]; then
   mkdir -p "${PROJ_DIR}"
-  # Replace existing memory dir (not a symlink) with the symlink
   if [[ -d "${PROJ_DIR}/memory" && ! -L "${PROJ_DIR}/memory" ]]; then
     rm -rf "${PROJ_DIR}/memory"
   fi
-  ln -sfn "${WORKSPACE_MEMORY}" "${PROJ_DIR}/memory"
+  ln -sfn "${WORKSPACE_CLAUDE}/memory" "${PROJ_DIR}/memory"
   echo "    Linked Claude Code memory → workspace (.claude/memory/)"
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,21 @@ Claude Code's tool permissions are encoded in `.claude/settings.json` using tool
 
 The slash commands above form a closed loop: `/improve-repo` audits the full repo, `/update-deps` keeps dependencies current, `/audit-security` verifies isolation, and `/add-toolchain` extends capabilities. Findings are proposed as branches, never committed directly to main. The `.github/ISSUE_TEMPLATE/claude-improvement.md` template provides a structured format for tracking AI-proposed changes.
 
+## Claude Code config wiring
+
+The repo's `.claude/` directory is the live config for Claude Code inside the container. At container start, `post-create.sh` (WSL2) / `run.sh` (macOS) creates symlinks:
+
+| `~/.claude/` path | Source |
+|---|---|
+| `commands/` | `/workspace/.claude/commands/` (slash commands) |
+| `settings.json` | `/workspace/.claude/settings.json` (permissions) |
+| `projects/-workspace/memory/` | `/workspace/.claude/memory/` (portable memory) |
+
+This means edits to `.claude/` in the repo take effect immediately without rebuild.
+
 ## Context persistence
 
-Claude Code memory is committed to the repo at `.claude/memory/`. At container start, `post-create.sh` symlinks `~/.claude/projects/-workspace/memory/` → `/workspace/.claude/memory/` so runtime writes land in the workspace. This makes context portable across machines and container rebuilds.
+Claude Code memory is committed to the repo at `.claude/memory/`. The memory symlink above ensures runtime writes land in the workspace and get committed. This makes context portable across machines and container rebuilds.
 
 A pre-commit hook (`scripts/hooks/pre-commit`) scans memory files for secret patterns (API keys, tokens, private keys, etc.) and blocks the commit if any are found. **Never store credentials or sensitive values in memory files.**
 

--- a/scripts/macos/run.sh
+++ b/scripts/macos/run.sh
@@ -85,18 +85,31 @@ container exec "${CONTAINER_NAME}" bash -c '
   fi
 ' 2>&1 || echo "    WARNING: credential copy failed — you may need to run claude login manually"
 
-# Set up memory symlink and pre-commit hook (same as post-create.sh does on WSL2)
+# Wire workspace .claude/ config into ~/.claude/ (mirrors post-create.sh on WSL2)
 container exec "${CONTAINER_NAME}" bash -c '
-  WORKSPACE_MEMORY="/workspace/.claude/memory"
+  WORKSPACE_CLAUDE="/workspace/.claude"
+
+  if [ -d "${WORKSPACE_CLAUDE}/commands" ]; then
+    rm -rf /home/claude/.claude/commands
+    ln -sfn "${WORKSPACE_CLAUDE}/commands" /home/claude/.claude/commands
+    echo "    Linked ~/.claude/commands → workspace (.claude/commands/)"
+  fi
+
+  if [ -f "${WORKSPACE_CLAUDE}/settings.json" ]; then
+    ln -sfn "${WORKSPACE_CLAUDE}/settings.json" /home/claude/.claude/settings.json
+    echo "    Linked ~/.claude/settings.json → workspace (.claude/settings.json)"
+  fi
+
   PROJ_DIR="/home/claude/.claude/projects/-workspace"
-  if [ -d "${WORKSPACE_MEMORY}" ]; then
+  if [ -d "${WORKSPACE_CLAUDE}/memory" ]; then
     mkdir -p "${PROJ_DIR}"
     if [ -d "${PROJ_DIR}/memory" ] && [ ! -L "${PROJ_DIR}/memory" ]; then
       rm -rf "${PROJ_DIR}/memory"
     fi
-    ln -sfn "${WORKSPACE_MEMORY}" "${PROJ_DIR}/memory"
+    ln -sfn "${WORKSPACE_CLAUDE}/memory" "${PROJ_DIR}/memory"
     echo "    Linked Claude Code memory → workspace (.claude/memory/)"
   fi
+
   if [ -d /workspace/.git ] && [ -f /workspace/scripts/hooks/pre-commit ]; then
     ln -sf ../../scripts/hooks/pre-commit /workspace/.git/hooks/pre-commit
     echo "    Installed pre-commit hook (secret scanning for memory files)"

--- a/tests/container-checks.sh
+++ b/tests/container-checks.sh
@@ -50,9 +50,10 @@ if [ "${CI:-false}" = "true" ]; then
   echo "  SKIP  memory symlink target is correct (post-create.sh not run in CI)"
   echo "  SKIP  pre-commit hook installed (post-create.sh not run in CI)"
 else
-  check "workspace memory dir exists"      test -d /workspace/.claude/memory
+  check "workspace .claude dir exists"     test -d /workspace/.claude
+  check "commands symlink is set up"       test -L "${HOME}/.claude/commands"
+  check "settings.json symlink is set up"  test -L "${HOME}/.claude/settings.json"
   check "memory symlink is set up"         test -L "${HOME}/.claude/projects/-workspace/memory"
-  check "memory symlink target is correct" test "$(readlink "${HOME}/.claude/projects/-workspace/memory")" = "/workspace/.claude/memory"
   check "pre-commit hook installed"        test -x /workspace/.git/hooks/pre-commit
 fi
 


### PR DESCRIPTION
## Problem

Inside the devcontainer, `~/.claude/` was missing `commands/`, `memory/`, and had a different `settings.json` than the repo. Claude Code reads its config from `~/.claude/` — not `/workspace/.claude/` — so the repo-committed slash commands and permissions were never active.

## Fix

At container start, `post-create.sh` (WSL2) and `run.sh` (macOS) now create symlinks:

| `~/.claude/` path | Source |
|---|---|
| `commands/` | `/workspace/.claude/commands/` |
| `settings.json` | `/workspace/.claude/settings.json` |
| `projects/-workspace/memory/` | `/workspace/.claude/memory/` |

Edits to `.claude/` in the repo now take effect immediately without a rebuild.

## Test plan

- [ ] Rebuild container — verify `~/.claude/commands/` exists and contains the slash commands
- [ ] Verify `~/.claude/settings.json` matches `/workspace/.claude/settings.json`
- [ ] Run `/improve-repo` or `/audit-security` inside the container — command should be found
- [ ] `bash tests/container-checks.sh` passes (commands + settings.json symlink checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)