### PR TITLE
fix: run post-create.sh from workspace, not from baked-in image copy

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -121,9 +121,4 @@ COPY --chown=${USERNAME}:${USERNAME} \
     .devcontainer/config/storage.conf \
     /home/${USERNAME}/.config/containers/storage.conf
 
-COPY --chown=${USERNAME}:${USERNAME} \
-    .devcontainer/scripts/post-create.sh \
-    /home/${USERNAME}/.devcontainer/post-create.sh
-RUN chmod +x /home/${USERNAME}/.devcontainer/post-create.sh
-
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,7 +55,9 @@
   // credentials don't exist yet on the host machine.
   "initializeCommand": "bash -c '[ -f \"${HOME}/.claude.json\" ] || echo \"{}\" > \"${HOME}/.claude.json\"; [ -d \"${HOME}/.claude\" ] || mkdir -p \"${HOME}/.claude\"; [ -d \"${HOME}/.config/gh\" ] || mkdir -p \"${HOME}/.config/gh\"; [ -f \"${HOME}/.gitconfig\" ] || touch \"${HOME}/.gitconfig\"'",
 
-  "postCreateCommand": "bash -c 'if [ -f /run/host-secrets/claude.json ]; then cp /run/host-secrets/claude.json $HOME/.claude.json && chmod 600 $HOME/.claude.json; fi; if [ -d /run/host-secrets/claude-dir ]; then for f in settings.json .credentials.json; do [ -f /run/host-secrets/claude-dir/$f ] && cp /run/host-secrets/claude-dir/$f $HOME/.claude/$f && chmod 600 $HOME/.claude/$f; done; [ -d /run/host-secrets/claude-dir/sessions ] && cp -r /run/host-secrets/claude-dir/sessions $HOME/.claude/; fi; if [ -f /run/host-secrets/gitconfig ]; then cp /run/host-secrets/gitconfig $HOME/.gitconfig && chmod 644 $HOME/.gitconfig; fi; bash $HOME/.devcontainer/post-create.sh'",
+  // post-create.sh is run from the workspace (not baked into the image) so that
+  // changes to the script take effect on "Reopen in Container" without make build.
+  "postCreateCommand": "bash -c 'if [ -f /run/host-secrets/claude.json ]; then cp /run/host-secrets/claude.json $HOME/.claude.json && chmod 600 $HOME/.claude.json; fi; if [ -d /run/host-secrets/claude-dir ]; then for f in settings.json .credentials.json; do [ -f /run/host-secrets/claude-dir/$f ] && cp /run/host-secrets/claude-dir/$f $HOME/.claude/$f && chmod 600 $HOME/.claude/$f; done; [ -d /run/host-secrets/claude-dir/sessions ] && cp -r /run/host-secrets/claude-dir/sessions $HOME/.claude/; fi; if [ -f /run/host-secrets/gitconfig ]; then cp /run/host-secrets/gitconfig $HOME/.gitconfig && chmod 644 $HOME/.gitconfig; fi; bash /workspace/.devcontainer/scripts/post-create.sh'",
 
   // Mount host Claude credentials so Claude Code is already authenticated.
   // Individual files are staged into /run/host-secrets/ (directory mount, more

--- a/scripts/macos/run.sh
+++ b/scripts/macos/run.sh
@@ -85,44 +85,10 @@ container exec "${CONTAINER_NAME}" bash -c '
   fi
 ' 2>&1 || echo "    WARNING: credential copy failed — you may need to run claude login manually"
 
-# Wire workspace .claude/ config into ~/.claude/ (mirrors post-create.sh on WSL2)
-container exec "${CONTAINER_NAME}" bash -c '
-  WORKSPACE_CLAUDE="/workspace/.claude"
-
-  if [ -d "${WORKSPACE_CLAUDE}/commands" ]; then
-    rm -rf /home/claude/.claude/commands
-    ln -sfn "${WORKSPACE_CLAUDE}/commands" /home/claude/.claude/commands
-    echo "    Linked ~/.claude/commands → workspace (.claude/commands/)"
-  fi
-
-  if [ -f "${WORKSPACE_CLAUDE}/settings.json" ]; then
-    ln -sfn "${WORKSPACE_CLAUDE}/settings.json" /home/claude/.claude/settings.json
-    echo "    Linked ~/.claude/settings.json → workspace (.claude/settings.json)"
-  fi
-
-  PROJ_DIR="/home/claude/.claude/projects/-workspace"
-  if [ -d "${WORKSPACE_CLAUDE}/memory" ]; then
-    mkdir -p "${PROJ_DIR}"
-    if [ -d "${PROJ_DIR}/memory" ] && [ ! -L "${PROJ_DIR}/memory" ]; then
-      rm -rf "${PROJ_DIR}/memory"
-    fi
-    ln -sfn "${WORKSPACE_CLAUDE}/memory" "${PROJ_DIR}/memory"
-    echo "    Linked Claude Code memory → workspace (.claude/memory/)"
-  fi
-
-  if [ -d /workspace/.git ] && [ -f /workspace/scripts/hooks/pre-commit ]; then
-    ln -sf ../../scripts/hooks/pre-commit /workspace/.git/hooks/pre-commit
-    echo "    Installed pre-commit hook (secret scanning for memory files)"
-  fi
-' 2>&1 || true
-
-# Run the same environment setup as post-create.sh
-container exec "${CONTAINER_NAME}" bash -c '
-  sudo mount --make-rshared / 2>/dev/null || true
-  sudo chmod 666 /dev/fuse 2>/dev/null || true
-  sudo chmod 666 /dev/net/tun 2>/dev/null || true
-  podman system migrate 2>/dev/null || true
-' 2>&1 || true
+# Run post-create.sh from the workspace — same script as WSL2's postCreateCommand.
+# Running from /workspace means changes take effect without rebuilding the image.
+container exec "${CONTAINER_NAME}" bash /workspace/.devcontainer/scripts/post-create.sh \
+  2>&1 || echo "    WARNING: post-create.sh failed — check container logs"
 
 echo ""
 echo "Container '${CONTAINER_NAME}' is running."


### PR DESCRIPTION
## Root cause

`post-create.sh` was `COPY`ed into the image at build time (`~/.devcontainer/post-create.sh`). Any changes to it — including the `.claude/` config wiring added in #8 — required `make build` to take effect. That's why the previous fix appeared to do nothing.

## Fix

Remove the `COPY` from the Containerfile entirely. Both platforms now run the script directly from the mounted workspace:

- **WSL2**: `postCreateCommand` calls `bash /workspace/.devcontainer/scripts/post-create.sh`
- **macOS**: `run.sh` calls `container exec … bash /workspace/.devcontainer/scripts/post-create.sh`

Changes to `post-create.sh` now take effect on "Reopen in Container" / `make run` without a rebuild. Also removes the duplicated inline setup blocks from `run.sh` — `post-create.sh` is now the single source of truth for container initialisation on both platforms.

## Test plan

- [ ] **Without** `make build`, do "Reopen in Container" (WSL2) or `make run` (macOS)
- [ ] Verify `~/.claude/commands/` symlink exists inside container
- [ ] Verify `~/.claude/settings.json` symlink points to workspace
- [ ] Verify `~/.claude/projects/-workspace/memory/` symlink exists
- [ ] Verify slash commands (`/improve-repo` etc.) are available in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)