### PR TITLE
feat: auto-sync audit-log status when PR is merged or declined

### DIFF
--- a/.github/workflows/sync-knowledge.yml
+++ b/.github/workflows/sync-knowledge.yml
@@ -1,0 +1,53 @@
+name: Sync knowledge base on PR merge
+
+# Triggers when a PR is closed (merged or declined) against main.
+# Updates the matching audit-log.md entry status so the knowledge base
+# stays current without manual intervention.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+# Needs write access to commit the audit-log update back to main.
+permissions:
+  contents: write
+
+jobs:
+  sync-knowledge:
+    name: Update audit-log status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Check out main (post-merge state), not the PR branch.
+          ref: main
+
+      - name: Determine new status
+        id: status
+        run: |
+          if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "value=merged" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=declined" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update audit-log entry
+        id: update
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          STATUS="${{ steps.status.outputs.value }}"
+          echo "Branch: ${BRANCH} → ${STATUS}"
+          if bash scripts/sync-knowledge.sh "${BRANCH}" "${STATUS}"; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit audit-log update
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .knowledge/audit-log.md
+          git commit -m "chore: mark ${{ github.event.pull_request.head.ref }} as ${{ steps.status.outputs.value }} in audit-log [skip ci]"
+          git push

--- a/.knowledge/audit-log.md
+++ b/.knowledge/audit-log.md
@@ -58,7 +58,7 @@ Entries are prepended (newest first).
 
 **Findings:** 4 (0 critical, 2 recommended, 2 nice-to-have)
 **Branch:** improve/2026-04-09
-**Status:** proposed
+**Status:** merged
 
 ### Finding: CI template test missing .knowledge/ assertions
 - **Severity:** recommended

--- a/scripts/sync-knowledge.sh
+++ b/scripts/sync-knowledge.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Update .knowledge/audit-log.md when a PR branch is merged or declined.
+# Finds the entry with **Branch:** <branch> and flips its **Status:** proposed
+# to the requested status. Exits 0 if an entry was updated, 1 if not found.
+#
+# Usage: sync-knowledge.sh <branch-name> [merged|declined]
+# Called by: .github/workflows/sync-knowledge.yml on PR close
+set -euo pipefail
+
+BRANCH="${1:?Usage: sync-knowledge.sh <branch-name> [merged|declined]}"
+NEW_STATUS="${2:-merged}"
+AUDIT_LOG=".knowledge/audit-log.md"
+
+if [[ ! -f "${AUDIT_LOG}" ]]; then
+  echo "==> ${AUDIT_LOG} not found — nothing to update"
+  exit 1
+fi
+
+# awk pass: find the line that exactly matches "**Branch:** <branch>" and
+# update the next "**Status:** proposed" line within that entry.
+# Exact matching avoids partial hits (e.g. "fix/foo" matching "fix/foobar").
+# Only 'proposed' entries are updated — already-merged/declined entries are left alone.
+UPDATED=$(awk \
+  -v branch="${BRANCH}" \
+  -v newstatus="${NEW_STATUS}" \
+  -v changed=0 '
+    $0 == ("**Branch:** " branch)  { found=1 }
+    found && $0 == "**Status:** proposed" {
+      $0 = "**Status:** " newstatus
+      found=0
+      changed++
+    }
+    { print }
+    END { exit (changed > 0) ? 0 : 1 }
+  ' "${AUDIT_LOG}") || {
+  echo "==> No 'proposed' entry found for branch '${BRANCH}' — audit-log unchanged"
+  exit 1
+}
+
+printf '%s\n' "${UPDATED}" > "${AUDIT_LOG}"
+echo "==> Marked branch '${BRANCH}' as '${NEW_STATUS}' in ${AUDIT_LOG}"


### PR DESCRIPTION
## Summary

Closes the loop on the knowledge base: previously, audit-log entries stayed \`proposed\` forever because there was no mechanism to update them after a PR merged.

A new GitHub Actions workflow triggers on PR close (merged or declined) and runs \`scripts/sync-knowledge.sh\` to flip the matching \`**Status:** proposed\` entry to \`merged\` or \`declined\`, then commits back to main.

## How it works

1. PR is merged/closed against \`main\`
2. Workflow checks out \`main\` (post-merge state)
3. \`sync-knowledge.sh\` finds the audit-log entry where \`**Branch:** <branch>\` matches exactly
4. Flips \`**Status:** proposed\` → \`merged\` or \`declined\`
5. Commits \`.knowledge/audit-log.md\` back with \`[skip ci]\`

Entries with no matching branch (e.g. the \`/audit-security\` run with \`**Branch:** —\`) are left untouched — exact line matching prevents false hits.

## Test plan

- [ ] Merge one of the open improvement PRs and verify the workflow runs and commits an audit-log update
- [ ] Close (don't merge) a PR and verify the entry is marked \`declined\`
- [ ] Merge a PR whose branch has no audit-log entry — verify the workflow exits cleanly with no commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)