### PR TITLE
fix: export gh OAuth token from macOS Keychain for container use

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -55,7 +55,7 @@
   // Runs on the HOST before the container is created.
   // Creates empty placeholder files so the mounts below never fail if the
   // credentials don't exist yet on the host machine.
-  "initializeCommand": "bash -c '[ -f \"${HOME}/.claude.json\" ] || echo \"{}\" > \"${HOME}/.claude.json\"; [ -d \"${HOME}/.claude\" ] || mkdir -p \"${HOME}/.claude\"; [ -d \"${HOME}/.config/gh\" ] || mkdir -p \"${HOME}/.config/gh\"; [ -f \"${HOME}/.gitconfig\" ] || touch \"${HOME}/.gitconfig\"'",
+  "initializeCommand": "bash ${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.sh",
 
   // postCreateCommand CWD is workspaceFolder, so relative path works here
   // and avoids hardcoding /workspace vs /workspaces/<name>.

--- a/.devcontainer/scripts/initialize-host.sh
+++ b/.devcontainer/scripts/initialize-host.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# initializeCommand — runs on the HOST before the container is created.
+# Ensures placeholder files/directories exist so bind mounts succeed,
+# and exports gh auth tokens from the system credential store into a
+# container-compatible hosts.yml staging file.
+set -euo pipefail
+
+# ── Ensure placeholder files/dirs for bind mounts ───────────────────────────
+[ -f "${HOME}/.claude.json" ] || echo "{}" > "${HOME}/.claude.json"
+[ -d "${HOME}/.claude" ] || mkdir -p "${HOME}/.claude"
+[ -d "${HOME}/.config/gh" ] || mkdir -p "${HOME}/.config/gh"
+[ -f "${HOME}/.gitconfig" ] || touch "${HOME}/.gitconfig"
+
+# ── Export gh OAuth token for container use ──────────────────────────────────
+# On macOS, gh stores tokens in the system Keychain — not in hosts.yml.
+# The container can't access the Keychain, so we extract the token here
+# (on the host) and write a container-compatible hosts.yml staging file.
+# post-create.sh will use this as the container's hosts.yml.
+GH_STAGED="${HOME}/.config/gh/.devcontainer-hosts.yml"
+
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+  if [[ -n "${GH_TOKEN}" ]]; then
+    GH_USER="$(gh api user --jq .login 2>/dev/null || echo "")"
+    GH_PROTO="$(gh config get git_protocol 2>/dev/null || echo "https")"
+    cat > "${GH_STAGED}" <<YEOF
+github.com:
+    oauth_token: ${GH_TOKEN}
+    git_protocol: ${GH_PROTO}
+    user: ${GH_USER}
+YEOF
+    chmod 600 "${GH_STAGED}"
+    echo "[initializeCommand] Exported gh token to staging file"
+  else
+    echo "[initializeCommand] gh authenticated but token extraction failed — skipping"
+    rm -f "${GH_STAGED}"
+  fi
+else
+  echo "[initializeCommand] gh not installed or not authenticated — skipping token export"
+  rm -f "${GH_STAGED}"
+fi

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -32,7 +32,16 @@ fi
 if [[ -d /run/host-secrets/gh ]]; then
   sudo cp -r /run/host-secrets/gh/. "$HOME/.config/gh/"
   sudo chown -R "$(id -u):$(id -g)" "$HOME/.config/gh"
-  echo "    Copied ~/.config/gh/"
+
+  # If the host exported a token-bearing staging file, use it as hosts.yml.
+  # This handles macOS where gh stores tokens in the Keychain (not in hosts.yml).
+  if [[ -f "$HOME/.config/gh/.devcontainer-hosts.yml" ]]; then
+    mv "$HOME/.config/gh/.devcontainer-hosts.yml" "$HOME/.config/gh/hosts.yml"
+    chmod 600 "$HOME/.config/gh/hosts.yml"
+    echo "    Copied ~/.config/gh/ (with exported token)"
+  else
+    echo "    Copied ~/.config/gh/"
+  fi
 fi
 
 if [[ -f /run/host-secrets/gitconfig ]]; then
@@ -95,6 +104,15 @@ if [[ -d "${WORKSPACE_ROOT}/.git" && -f "${WORKSPACE_ROOT}/scripts/hooks/pre-com
   ln -s ../../scripts/hooks/pre-commit "${WORKSPACE_ROOT}/.git/hooks/pre-commit"
   chmod +x "${WORKSPACE_ROOT}/scripts/hooks/pre-commit"
   echo "    Installed pre-commit hook (secret scanning)"
+fi
+
+# ── Fix workspace file permissions ───────────────────────────────────────────
+# On virtiofs mounts (Podman on macOS), the host UID maps to root inside the
+# container. chown fails on virtiofs, but chmod works. Make the workspace and
+# .git writable so the container user can edit files and use git.
+if [[ -d "${WORKSPACE_ROOT}" ]]; then
+  sudo find "${WORKSPACE_ROOT}" -not -writable -exec chmod a+w {} + 2>/dev/null || true
+  echo "    Fixed workspace file permissions"
 fi
 
 # ── Podman / nested container setup ──────────────────────────────────────────

--- a/tests/container-checks.sh
+++ b/tests/container-checks.sh
@@ -58,6 +58,42 @@ else
   check "pre-commit hook installed"        test -x "${PWD}/.git/hooks/pre-commit"
 fi
 
+# ── Workspace file permissions ────────────────────────────────────────────────
+# On virtiofs mounts (Podman on macOS), host files map as root inside the
+# container. post-create.sh fixes this, but we verify critical paths here.
+echo "==> Workspace file permissions"
+if [ "${CI:-false}" = "true" ]; then
+  echo "  SKIP  workspace permissions (workspace not mounted in CI)"
+else
+  # Files and dirs that must be writable for day-to-day development
+  check "workspace root is writable"             test -w "${PWD}"
+  check ".git dir is writable"                   test -w "${PWD}/.git"
+  check ".git/refs/heads is writable"            test -w "${PWD}/.git/refs/heads"
+  check ".devcontainer dir is writable"          test -w "${PWD}/.devcontainer"
+  check ".devcontainer/scripts dir is writable"  test -w "${PWD}/.devcontainer/scripts"
+  check "Makefile is writable"                   test -w "${PWD}/Makefile"
+  check "CLAUDE.md is writable"                  test -w "${PWD}/CLAUDE.md"
+
+  # Credential dirs must be writable for token refresh
+  check "~/.config/gh dir is writable"           test -w "${HOME}/.config/gh"
+  check "~/.claude dir is writable"              test -w "${HOME}/.claude"
+
+  # Verify we can actually create and remove a file (not just stat-based check)
+  check "can create file in workspace" bash -c 'f="${PWD}/.permission-test-$$"; touch "$f" && rm "$f"'
+  check "can create git branch" bash -c 'git branch __permission-test 2>/dev/null && git branch -d __permission-test >/dev/null 2>&1'
+fi
+
+# ── GitHub CLI authentication ────────────────────────────────────────────────
+echo "==> GitHub CLI"
+if [ "${CI:-false}" = "true" ]; then
+  echo "  SKIP  gh auth (not configured in CI)"
+else
+  check "gh is installed"                command -v gh
+  check "gh hosts.yml exists"            test -f "${HOME}/.config/gh/hosts.yml"
+  # Token presence check — don't validate against API (may be rate-limited)
+  check "gh hosts.yml contains token"    grep -q "oauth_token" "${HOME}/.config/gh/hosts.yml"
+fi
+
 # ── Nested container smoke test ───────────────────────────────────────────────
 # Skipped in CI: nested user namespaces require kernel-level support that
 # GitHub Actions standard runners do not provide (newuidmap cannot remap IDs


### PR DESCRIPTION
## Summary
- Adds `initialize-host.sh` that runs on the host before container creation to extract the `gh` OAuth token from the macOS Keychain and stage it as a container-compatible `hosts.yml`
- Updates `post-create.sh` to use the staged token file when present, and fixes workspace file permissions on virtiofs mounts (Podman on macOS)
- Adds container checks for workspace permissions and gh authentication

## Test plan
- [ ] Verify `gh auth status` works inside the container on macOS (Podman)
- [ ] Verify `gh auth status` works inside the container on WSL2
- [ ] Verify workspace files are writable inside the container on macOS
- [ ] Run `bash tests/container-checks.sh` inside the container — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)