### PR TITLE
feat: extract Claude Code OAuth token from macOS Keychain

### DIFF
--- a/.devcontainer/scripts/credential-watcher.sh
+++ b/.devcontainer/scripts/credential-watcher.sh
@@ -23,10 +23,13 @@ copy_credentials() {
   fi
 
   if [[ -f "${WATCH_DIR}/claude-dir/.credentials.json" ]]; then
-    sudo cp "${WATCH_DIR}/claude-dir/.credentials.json" "$HOME/.claude/.credentials.json"
-    sudo chown "$(id -u):$(id -g)" "$HOME/.claude/.credentials.json"
-    chmod 600 "$HOME/.claude/.credentials.json"
-    echo "${LOG_PREFIX} Refreshed ~/.claude/.credentials.json"
+    # Only overwrite with a non-empty file to avoid blanking Keychain-exported credentials
+    if sudo test -s "${WATCH_DIR}/claude-dir/.credentials.json"; then
+      sudo cp "${WATCH_DIR}/claude-dir/.credentials.json" "$HOME/.claude/.credentials.json"
+      sudo chown "$(id -u):$(id -g)" "$HOME/.claude/.credentials.json"
+      chmod 600 "$HOME/.claude/.credentials.json"
+      echo "${LOG_PREFIX} Refreshed ~/.claude/.credentials.json"
+    fi
   fi
 
   if [[ -d "${WATCH_DIR}/claude-dir/sessions" ]]; then

--- a/.devcontainer/scripts/initialize-host.sh
+++ b/.devcontainer/scripts/initialize-host.sh
@@ -39,3 +39,60 @@ else
   echo "[initializeCommand] gh not installed or not authenticated — skipping token export"
   rm -f "${GH_STAGED}"
 fi
+
+# ── Export Claude Code credentials for container use ───────────────────────
+# On macOS, Claude Code may store OAuth tokens in the system Keychain rather
+# than in ~/.claude/.credentials.json. The container can't access the Keychain,
+# so we extract the token here (on the host) and write a staging file.
+# post-create.sh will use this as the container's .credentials.json.
+CLAUDE_STAGED="${HOME}/.claude/.devcontainer-credentials.json"
+rm -f "${CLAUDE_STAGED}"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  CLAUDE_CREDS="${HOME}/.claude/.credentials.json"
+
+  # Skip if filesystem credentials already contain a token
+  if [[ -s "${CLAUDE_CREDS}" ]] && grep -q '"token"' "${CLAUDE_CREDS}" 2>/dev/null; then
+    echo "[initializeCommand] Claude credentials already on filesystem — skipping Keychain export"
+  else
+    # Try known Keychain service names used by Claude Code.
+    # Allow override via env var for non-standard installations.
+    CLAUDE_TOKEN=""
+    KEYCHAIN_SERVICES=("claude.ai" "api.anthropic.com" "com.anthropic.claude-code" "claude-code")
+    if [[ -n "${CLAUDE_KEYCHAIN_SERVICE:-}" ]]; then
+      KEYCHAIN_SERVICES=("${CLAUDE_KEYCHAIN_SERVICE}" "${KEYCHAIN_SERVICES[@]}")
+    fi
+
+    for SERVICE in "${KEYCHAIN_SERVICES[@]}"; do
+      CLAUDE_TOKEN="$(security find-generic-password -s "${SERVICE}" -w 2>/dev/null || true)"
+      if [[ -n "${CLAUDE_TOKEN}" ]]; then
+        echo "[initializeCommand] Found Claude token in Keychain (service: ${SERVICE})"
+        break
+      fi
+      # Also try internet password entries (URL-based)
+      CLAUDE_TOKEN="$(security find-internet-password -s "${SERVICE}" -w 2>/dev/null || true)"
+      if [[ -n "${CLAUDE_TOKEN}" ]]; then
+        echo "[initializeCommand] Found Claude token in Keychain (internet-password: ${SERVICE})"
+        break
+      fi
+    done
+
+    if [[ -n "${CLAUDE_TOKEN}" ]]; then
+      # Write staging file. post-create.sh will move this into place.
+      # Format mirrors Claude Code's .credentials.json structure.
+      cat > "${CLAUDE_STAGED}" <<CEOF
+{
+  "claudeAiOauth": {
+    "token": "${CLAUDE_TOKEN}"
+  }
+}
+CEOF
+      chmod 600 "${CLAUDE_STAGED}"
+      echo "[initializeCommand] Exported Claude token to staging file"
+    else
+      echo "[initializeCommand] No Claude token found in Keychain — skipping"
+    fi
+  fi
+else
+  echo "[initializeCommand] Not macOS — skipping Keychain export"
+fi

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -22,6 +22,13 @@ if [[ -d /run/host-secrets/claude-dir ]]; then
     chmod 600 "$HOME/.claude/.credentials.json"
     echo "    Copied ~/.claude/.credentials.json"
   fi
+  # If the host exported Keychain credentials, use them (overrides empty file copy).
+  # This handles macOS where Claude Code stores tokens in the Keychain, not on disk.
+  if [[ -f "$HOME/.claude/.devcontainer-credentials.json" ]]; then
+    mv "$HOME/.claude/.devcontainer-credentials.json" "$HOME/.claude/.credentials.json"
+    chmod 600 "$HOME/.claude/.credentials.json"
+    echo "    Applied Keychain-exported Claude credentials"
+  fi
   if [[ -d /run/host-secrets/claude-dir/sessions ]]; then
     sudo cp -r /run/host-secrets/claude-dir/sessions "$HOME/.claude/"
     sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude/sessions"
@@ -108,10 +115,12 @@ fi
 
 # ── Fix workspace file permissions ───────────────────────────────────────────
 # On virtiofs mounts (Podman on macOS), the host UID maps to root inside the
-# container. chown fails on virtiofs, but chmod works. Make the workspace and
-# .git writable so the container user can edit files and use git.
+# container. chown fails on virtiofs, but chmod works. Make the entire workspace
+# writable so the container user can edit all files and use git.
+# Run chmod on all non-writable files/dirs — not just a subset.
 if [[ -d "${WORKSPACE_ROOT}" ]]; then
-  sudo find "${WORKSPACE_ROOT}" -not -writable -exec chmod a+w {} + 2>/dev/null || true
+  sudo chmod -R a+w "${WORKSPACE_ROOT}" 2>/dev/null || \
+    sudo find "${WORKSPACE_ROOT}" -not -writable -exec chmod a+w {} + 2>/dev/null || true
   echo "    Fixed workspace file permissions"
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Host credentials are bind-mounted read-only into `/run/host-secrets/` and then c
 
 Host-mounted files may be owned by a different UID (e.g. root) with mode 600. `post-create.sh` uses `sudo cp` + `chown` to handle this.
 
+On macOS, Claude Code and GitHub CLI may store tokens in the system Keychain instead of on disk. `initialize-host.sh` (runs on the host via `initializeCommand`) extracts these tokens into staging files before container creation. `post-create.sh` detects staging files and moves them into the container's writable credential locations. Set `CLAUDE_KEYCHAIN_SERVICE` to override the Keychain service name if needed.
+
 ### Nested container support
 
 Rootless Podman inside the devcontainer enables Claude Code to spawn containers at runtime. Key pieces:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,17 @@ Host-mounted files may be owned by a different UID (e.g. root) with mode 600. `p
 
 The `/run/host-secrets/` staging area exists because direct bind mounts of individual files have portability issues across container runtimes (UID mapping, filesystem notifications). The copy-on-create pattern is more reliable.
 
+### macOS Keychain Extraction
+
+On macOS, both Claude Code and GitHub CLI may store OAuth tokens in the system Keychain rather than in filesystem config files. Since the Keychain is a macOS-only subsystem, these tokens are invisible to the Linux container.
+
+`initialize-host.sh` (runs on the host via `initializeCommand`) extracts tokens before container creation:
+
+- **GitHub CLI**: `gh auth token` → staged to `~/.config/gh/.devcontainer-hosts.yml`
+- **Claude Code**: `security find-generic-password` → staged to `~/.claude/.devcontainer-credentials.json`
+
+`post-create.sh` detects these staging files and moves them into the container's writable credential locations, overriding any empty filesystem copies. Staging files are consumed (moved, not copied) so they don't persist.
+
 ## Nested Container Architecture
 
 The inner Podman is configured for rootless operation inside an already-namespaced environment:

--- a/docs/SANDBOX-MODEL.md
+++ b/docs/SANDBOX-MODEL.md
@@ -59,12 +59,13 @@ This document describes the isolation boundaries for the Claude Code container e
 ## Credential Lifecycle
 
 1. Host credentials are created by the user (e.g., `claude login`, `gh auth login`)
-2. At container start, credentials are mounted read-only into `/run/host-secrets/`
-3. `postCreateCommand` / `run.sh` copies them to writable locations
-4. A background credential watcher (`inotifywait`) monitors `/run/host-secrets/` for changes and auto-copies updated credentials into the container
-5. Claude Code uses the writable copies (it needs write access for token refresh)
-6. On container stop, writable copies are destroyed (container is ephemeral)
-7. Token refresh writes go to the container-local copy, NOT back to the host
+2. On macOS, `initializeCommand` extracts Keychain-stored tokens (Claude Code, GitHub CLI) into staging files. These tokens cannot be bind-mounted — the Keychain is a macOS-only subsystem unavailable inside the Linux container.
+3. At container start, credentials are mounted read-only into `/run/host-secrets/`
+4. `postCreateCommand` copies them to writable locations. Keychain-staged credentials (if present) override empty filesystem copies.
+5. A background credential watcher (`inotifywait`) monitors `/run/host-secrets/` for changes and auto-copies updated credentials into the container
+6. Claude Code uses the writable copies (it needs write access for token refresh)
+7. On container stop, writable copies are destroyed (container is ephemeral)
+8. Token refresh writes go to the container-local copy, NOT back to the host
 
 **Credential auto-refresh**: When the host rotates credentials (e.g., Claude auth token refresh), the `inotifywait`-based watcher detects the change and copies the updated file into `~/.claude/`. Log output goes to `/tmp/credential-watcher.log` inside the container.
 

--- a/tests/container-checks.sh
+++ b/tests/container-checks.sh
@@ -75,11 +75,11 @@ else
   check "CLAUDE.md is writable"                  test -w "${PWD}/CLAUDE.md"
 
   # Credential dirs must be writable for token refresh
-  check "~/.config/gh dir is writable"           test -w "${HOME}/.config/gh"
-  check "~/.claude dir is writable"              test -w "${HOME}/.claude"
+  check "$HOME/.config/gh dir is writable"       test -w "${HOME}/.config/gh"
+  check "$HOME/.claude dir is writable"          test -w "${HOME}/.claude"
 
   # Verify we can actually create and remove a file (not just stat-based check)
-  check "can create file in workspace" bash -c 'f="${PWD}/.permission-test-$$"; touch "$f" && rm "$f"'
+  check "can create file in workspace" bash -c "f=\"\${PWD}/.permission-test-\$\$\"; touch \"\$f\" && rm \"\$f\""
   check "can create git branch" bash -c 'git branch __permission-test 2>/dev/null && git branch -d __permission-test >/dev/null 2>&1'
 fi
 
@@ -88,8 +88,8 @@ echo "==> Claude Code credentials"
 if [ "${CI:-false}" = "true" ]; then
   echo "  SKIP  claude credentials (not configured in CI)"
 else
-  check "~/.claude.json exists"                test -f "${HOME}/.claude.json"
-  check "~/.claude/.credentials.json exists"   test -f "${HOME}/.claude/.credentials.json"
+  check "$HOME/.claude.json exists"             test -f "${HOME}/.claude.json"
+  check "$HOME/.claude/.credentials.json exists" test -f "${HOME}/.claude/.credentials.json"
   check ".credentials.json is non-empty"       test -s "${HOME}/.claude/.credentials.json"
 fi
 

--- a/tests/container-checks.sh
+++ b/tests/container-checks.sh
@@ -83,6 +83,16 @@ else
   check "can create git branch" bash -c 'git branch __permission-test 2>/dev/null && git branch -d __permission-test >/dev/null 2>&1'
 fi
 
+# ── Claude Code authentication ───────────────────────────────────────────────
+echo "==> Claude Code credentials"
+if [ "${CI:-false}" = "true" ]; then
+  echo "  SKIP  claude credentials (not configured in CI)"
+else
+  check "~/.claude.json exists"                test -f "${HOME}/.claude.json"
+  check "~/.claude/.credentials.json exists"   test -f "${HOME}/.claude/.credentials.json"
+  check ".credentials.json is non-empty"       test -s "${HOME}/.claude/.credentials.json"
+fi
+
 # ── GitHub CLI authentication ────────────────────────────────────────────────
 echo "==> GitHub CLI"
 if [ "${CI:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Extract Claude Code OAuth tokens from macOS Keychain in `initialize-host.sh`, mirroring the GitHub CLI pattern from #28
- `post-create.sh` consumes Keychain-staged credentials, overriding empty filesystem copies
- Credential watcher now skips empty files to avoid blanking Keychain-exported credentials
- Improved workspace permission handling (`chmod -R` with `find` fallback)
- Updated docs (ARCHITECTURE.md, SANDBOX-MODEL.md, CLAUDE.md) and added credential checks to tests

## Test plan
- [ ] On macOS with Claude Code tokens in Keychain: rebuild container, verify `~/.claude/.credentials.json` contains the token
- [ ] On macOS with Claude Code tokens on disk: verify Keychain export is skipped
- [ ] On WSL2: verify Keychain section is skipped gracefully
- [ ] Run `bash tests/container-checks.sh` inside the container — new credential checks should pass
- [ ] CI: verify new test checks are skipped (CI flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)