### PR TITLE
fix: add --userns=keep-id UID mapping for workspace file ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
   // networking — a userspace implementation that does not require the tun kernel device.
   // (pasta, the Podman 5.x default, would need /dev/net/tun; slirp4netns does not.)
   "runArgs": [
+    "--userns=keep-id:uid=1000,gid=1000",
     "--security-opt", "seccomp=unconfined",
     "--security-opt", "apparmor=unconfined",
     "--device", "/dev/fuse",

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -114,11 +114,11 @@ if [[ -d "${WORKSPACE_ROOT}/.git" && -f "${WORKSPACE_ROOT}/scripts/hooks/pre-com
 fi
 
 # ── Fix workspace file permissions ───────────────────────────────────────────
-# On virtiofs mounts (Podman on macOS), the host UID maps to root inside the
-# container. chown fails on virtiofs, but chmod works. Make the entire workspace
-# writable so the container user can edit all files and use git.
-# Run chmod on all non-writable files/dirs — not just a subset.
+# With --userns=keep-id:uid=1000,gid=1000 in runArgs, virtiofs files should
+# already appear owned by the container user. The chown + chmod below are
+# fallbacks for edge cases (WSL2 bind mounts, or if keep-id is unavailable).
 if [[ -d "${WORKSPACE_ROOT}" ]]; then
+  sudo chown -R "$(id -u):$(id -g)" "${WORKSPACE_ROOT}" 2>/dev/null || true
   sudo chmod -R a+w "${WORKSPACE_ROOT}" 2>/dev/null || \
     sudo find "${WORKSPACE_ROOT}" -not -writable -exec chmod a+w {} + 2>/dev/null || true
   echo "    Fixed workspace file permissions"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,12 @@ Host (macOS / WSL2)
 
 VS Code uses the Dev Containers extension to build and start the container via the Podman socket. The `postCreateCommand` runs automatically after container creation.
 
+### Workspace UID Mapping
+
+On macOS, Podman uses virtiofs to mount the workspace into the container. Without UID mapping, the host user's UID (e.g., 501) appears as `root` inside the container, causing permission failures for git operations and file edits.
+
+`devcontainer.json` includes `--userns=keep-id:uid=1000,gid=1000` in `runArgs`, which maps the host user to UID 1000 (`claude`) inside the container. This ensures workspace files appear owned by the correct user. `post-create.sh` includes a `chown`/`chmod` fallback for environments where `keep-id` is unavailable.
+
 ## Credential Flow
 
 ```


### PR DESCRIPTION
## Summary
- Add `--userns=keep-id:uid=1000,gid=1000` to `runArgs` in `devcontainer.json` so workspace files appear owned by the container user (UID 1000) instead of root
- Update `post-create.sh` permission fix to be a fallback with `chown` + `chmod`, not the primary mechanism
- Document the UID mapping design in `docs/ARCHITECTURE.md`

## Test plan
- [ ] Rebuild container on macOS — verify workspace files owned by `claude` (not root)
- [ ] Rebuild container on WSL2 — verify no regression
- [ ] Run `ls -la /workspaces/<project>` inside container to confirm ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)