### PR TITLE
fix: dynamic host UID/GID mapping for macOS workspace ownership

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,12 @@
     "context": "..",
     "args": {
       "USERNAME": "claude",
-      "USER_UID": "1000",
-      "USER_GID": "1000"
+      // HOST_UID / HOST_GID are set by initializeCommand and persisted in
+      // the user's shell profile (~/.zprofile on macOS, ~/.bash_profile on
+      // WSL2). On macOS the default UID is 501; on WSL2 it's 1000. Using the
+      // host UID ensures the container user matches virtiofs file ownership.
+      "USER_UID": "${localEnv:HOST_UID:1000}",
+      "USER_GID": "${localEnv:HOST_GID:1000}"
     }
   },
 
@@ -23,7 +27,7 @@
   // networking — a userspace implementation that does not require the tun kernel device.
   // (pasta, the Podman 5.x default, would need /dev/net/tun; slirp4netns does not.)
   "runArgs": [
-    "--userns=keep-id:uid=1000,gid=1000",
+    "--userns=keep-id:uid=${localEnv:HOST_UID:1000},gid=${localEnv:HOST_GID:1000}",
     "--security-opt", "seccomp=unconfined",
     "--security-opt", "apparmor=unconfined",
     "--device", "/dev/fuse",

--- a/.devcontainer/scripts/initialize-host.sh
+++ b/.devcontainer/scripts/initialize-host.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # initializeCommand — runs on the HOST before the container is created.
 # Ensures placeholder files/directories exist so bind mounts succeed,
-# and exports gh auth tokens from the system credential store into a
-# container-compatible hosts.yml staging file.
+# exports gh auth tokens from the system credential store into a
+# container-compatible hosts.yml staging file, and persists HOST_UID/HOST_GID
+# for cross-platform UID mapping.
 set -euo pipefail
 
 # ── Ensure placeholder files/dirs for bind mounts ───────────────────────────
@@ -10,6 +11,44 @@ set -euo pipefail
 [ -d "${HOME}/.claude" ] || mkdir -p "${HOME}/.claude"
 [ -d "${HOME}/.config/gh" ] || mkdir -p "${HOME}/.config/gh"
 [ -f "${HOME}/.gitconfig" ] || touch "${HOME}/.gitconfig"
+
+# ── Persist HOST_UID / HOST_GID for devcontainer.json ────────────────────────
+# devcontainer.json references ${localEnv:HOST_UID:1000} in build args and
+# runArgs. VS Code reads these from its process environment, which inherits
+# from the user's shell profile. We write a small env file and add a source
+# line to the profile so the vars are available on every subsequent launch.
+#
+# On WSL2 (UID 1000) the default of 1000 already matches, so this is mainly
+# needed for macOS where the default UID is 501.
+HOST_ENV_FILE="${HOME}/.devcontainer-host-env"
+cat > "${HOST_ENV_FILE}" <<HEOF
+export HOST_UID=$(id -u)
+export HOST_GID=$(id -g)
+HEOF
+
+# Source it now (for any child processes in this script).
+# shellcheck disable=SC1090
+source "${HOST_ENV_FILE}"
+
+# Add persistent source line to the user's login profile (zsh on macOS,
+# bash on WSL2). Use .zprofile / .bash_profile so GUI-launched VS Code
+# (which sources login profiles) picks up the vars.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  PROFILE="${HOME}/.zprofile"
+else
+  PROFILE="${HOME}/.bash_profile"
+fi
+MARKER="# devcontainer-host-env"
+if ! grep -qF "${MARKER}" "${PROFILE}" 2>/dev/null; then
+  printf '\n%s\n[ -f "%s" ] && source "%s"\n' \
+    "${MARKER}" "${HOST_ENV_FILE}" "${HOST_ENV_FILE}" >> "${PROFILE}"
+  echo "[initializeCommand] Added HOST_UID/HOST_GID to ${PROFILE}"
+  echo "[initializeCommand] NOTE: If this is the first run, restart VS Code so it"
+  echo "                    picks up HOST_UID=${HOST_UID} HOST_GID=${HOST_GID},"
+  echo "                    then Rebuild Container."
+else
+  echo "[initializeCommand] HOST_UID=${HOST_UID} HOST_GID=${HOST_GID}"
+fi
 
 # ── Export gh OAuth token for container use ──────────────────────────────────
 # On macOS, gh stores tokens in the system Keychain — not in hosts.yml.

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -113,15 +113,26 @@ if [[ -d "${WORKSPACE_ROOT}/.git" && -f "${WORKSPACE_ROOT}/scripts/hooks/pre-com
   echo "    Installed pre-commit hook (secret scanning)"
 fi
 
-# ── Fix workspace file permissions ───────────────────────────────────────────
-# With --userns=keep-id:uid=1000,gid=1000 in runArgs, virtiofs files should
-# already appear owned by the container user. The chown + chmod below are
-# fallbacks for edge cases (WSL2 bind mounts, or if keep-id is unavailable).
+# ── Verify workspace file ownership ──────────────────────────────────────────
+# With --userns=keep-id, the host user's UID is mapped to the container user's
+# UID. If HOST_UID was set correctly in the user's environment (see
+# initializeCommand), the container user UID matches the host UID, and virtiofs
+# files appear owned by the container user on both WSL2 and macOS.
 if [[ -d "${WORKSPACE_ROOT}" ]]; then
-  sudo chown -R "$(id -u):$(id -g)" "${WORKSPACE_ROOT}" 2>/dev/null || true
-  sudo chmod -R a+w "${WORKSPACE_ROOT}" 2>/dev/null || \
-    sudo find "${WORKSPACE_ROOT}" -not -writable -exec chmod a+w {} + 2>/dev/null || true
-  echo "    Fixed workspace file permissions"
+  WORKSPACE_UID="$(stat -c %u "${WORKSPACE_ROOT}")"
+  CONTAINER_UID="$(id -u)"
+  if [[ "${WORKSPACE_UID}" == "${CONTAINER_UID}" ]]; then
+    echo "    Workspace ownership OK (UID ${CONTAINER_UID})"
+  elif [[ "${WORKSPACE_UID}" == "65534" ]]; then
+    echo "    WARNING: Workspace files owned by nobody (UID 65534)."
+    echo "    The host UID is not mapped in the container's user namespace."
+    echo "    Set HOST_UID/HOST_GID in your shell profile and rebuild:"
+    echo "      echo 'export HOST_UID=\$(id -u) HOST_GID=\$(id -g)' >> ~/.zprofile"
+    echo "    Then: Cmd+Shift+P → Dev Containers: Rebuild Container"
+  else
+    echo "    WARNING: Workspace owned by UID ${WORKSPACE_UID}, container user is ${CONTAINER_UID}."
+    echo "    Set HOST_UID=${WORKSPACE_UID} HOST_GID=$(stat -c %g "${WORKSPACE_ROOT}") in your shell profile and rebuild."
+  fi
 fi
 
 # ── Podman / nested container setup ──────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ CI builds via `podman build` with `--platform linux/amd64`; macOS builds use `--
 
 Both platforms use the standard Dev Containers lifecycle: `devcontainer.json` controls `build`, `runArgs`, `postCreateCommand`, and volume `mounts`. VS Code's "Reopen in Container" handles everything.
 
+### Workspace UID mapping
+
+The container user UID is built from `HOST_UID` / `HOST_GID` environment variables (defaulting to 1000). `initializeCommand` detects the host UID and persists it in `~/.devcontainer-host-env`, which is sourced from the user's login profile. `devcontainer.json` references these via `${localEnv:HOST_UID:1000}` in both `build.args` and `--userns=keep-id` runArgs. On macOS (UID 501), this ensures the container user matches virtiofs file ownership. On WSL2 (UID 1000), the default already matches. First-time macOS users need one VS Code restart after the initial `initializeCommand` sets up the profile.
+
 ### Credential flow
 
 Host credentials are bind-mounted read-only into `/run/host-secrets/` and then copied to writable locations by `post-create.sh`:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,9 +26,11 @@ VS Code uses the Dev Containers extension to build and start the container via t
 
 ### Workspace UID Mapping
 
-On macOS, Podman uses virtiofs to mount the workspace into the container. Without UID mapping, the host user's UID (e.g., 501) appears as `root` inside the container, causing permission failures for git operations and file edits.
+On macOS, Podman uses virtiofs to mount the workspace into the container. Without UID mapping, the host user's UID (e.g., 501) appears as `nobody:nogroup` inside the container, causing permission failures for git operations and file edits. On WSL2, the host UID is typically 1000, matching the container user.
 
-`devcontainer.json` includes `--userns=keep-id:uid=1000,gid=1000` in `runArgs`, which maps the host user to UID 1000 (`claude`) inside the container. This ensures workspace files appear owned by the correct user. `post-create.sh` includes a `chown`/`chmod` fallback for environments where `keep-id` is unavailable.
+`devcontainer.json` uses `--userns=keep-id:uid=${localEnv:HOST_UID:1000},gid=${localEnv:HOST_GID:1000}` in `runArgs` and the same variables in `build.args`, so the container user's UID matches the host user's UID. `initializeCommand` (`initialize-host.sh`) detects the host UID/GID and persists them in `~/.devcontainer-host-env`, which is sourced from the user's login profile (`~/.zprofile` on macOS, `~/.bash_profile` on WSL2). VS Code reads these environment variables via `${localEnv:HOST_UID}` when parsing `devcontainer.json`.
+
+On first run, the env vars may not yet be in VS Code's process environment (defaults to 1000). After `initializeCommand` sets up the profile source, a VS Code restart + container rebuild picks up the correct UID. On WSL2 where UID is already 1000, the default always works.
 
 ## Credential Flow
 


### PR DESCRIPTION
## Summary

- **Problem**: On macOS, virtiofs presents workspace files with the host UID (501), which is outside the container's user namespace mapping when `--userns=keep-id` hardcodes `uid=1000`. Files appear as `nobody:nogroup` and all access is blocked — even `chown`/`chmod` by root fails because the UID is unmapped in the user namespace.
- **Fix**: Replace hardcoded UID 1000 with dynamic host UID detection via `${localEnv:HOST_UID:1000}` in `devcontainer.json` build args and `--userns=keep-id` runArgs. `initializeCommand` detects the host UID/GID and persists them in the user's login profile so VS Code picks them up.
- **WSL2**: Default of 1000 works without any env vars (no change in behavior).

### How it works

1. `initializeCommand` runs on the host, detects `id -u`/`id -g`, writes `~/.devcontainer-host-env`, and sources it from the login profile (`~/.zprofile` on macOS, `~/.bash_profile` on WSL2)
2. `devcontainer.json` uses `${localEnv:HOST_UID:1000}` in both `build.args` (Containerfile builds user with matching UID) and `--userns=keep-id:uid=...` (Podman maps host UID to container UID)
3. `post-create.sh` verifies workspace ownership and warns with clear instructions if mismatched (replaces silent `chown` that never worked on virtiofs)

### First-run note

On macOS, the first run defaults to UID 1000 (env vars not yet in VS Code's environment). After `initializeCommand` sets up the profile source, a VS Code restart + container rebuild picks up the correct UID automatically.

## Test plan

- [ ] WSL2: verify workspace files still owned by `claude:claude` (no behavior change)
- [ ] macOS: verify `initializeCommand` writes `~/.devcontainer-host-env` with UID 501
- [ ] macOS: after VS Code restart + rebuild, verify workspace files owned by `claude:claude`
- [ ] macOS: verify `post-create.sh` prints "Workspace ownership OK" on successful mapping
- [ ] macOS: verify `post-create.sh` prints warning with instructions on UID mismatch (first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)