### PR TITLE
fix: handle UID/GID conflicts in Containerfile for macOS

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -56,11 +56,23 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 # ── Non-root user ─────────────────────────────────────────────────────────────
 # Ubuntu 24.04 ships with an 'ubuntu' user already occupying UID/GID 1000.
-# Remove it first so our user can claim UID/GID 1000 without conflicts.
+# Remove it first so our user can claim the UID/GID without conflicts.
+# On macOS, HOST_GID is typically 20 (staff), which may already exist in
+# the image (e.g. Ubuntu's 'dialout' group). Use the existing group if the
+# GID is taken, or create a new one if it's free.
 RUN userdel -r ubuntu 2>/dev/null || true \
     && groupdel ubuntu 2>/dev/null || true
-RUN groupadd --gid ${USER_GID} ${USERNAME} \
-    && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/zsh ${USERNAME} \
+RUN if getent group ${USER_GID} >/dev/null 2>&1; then \
+      EXISTING_GROUP=$(getent group ${USER_GID} | cut -d: -f1); \
+    else \
+      groupadd --gid ${USER_GID} ${USERNAME}; \
+      EXISTING_GROUP=${USERNAME}; \
+    fi \
+    && if getent passwd ${USER_UID} >/dev/null 2>&1; then \
+      EXISTING_USER=$(getent passwd ${USER_UID} | cut -d: -f1); \
+      userdel -r "${EXISTING_USER}" 2>/dev/null || true; \
+    fi \
+    && useradd --uid ${USER_UID} --gid ${EXISTING_GROUP} -m -s /bin/zsh ${USERNAME} \
     && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
     && chmod 0440 /etc/sudoers.d/${USERNAME}
 


### PR DESCRIPTION
## Summary

- On macOS, `HOST_GID` is typically **20** (the `staff` group), which already exists in Ubuntu as `dialout`. `groupadd --gid 20` fails with exit status 4.
- Similarly, the host UID could conflict with an existing user in the image.
- Fix: check for existing GID/UID before creating, reuse existing group or remove conflicting user as needed.

This is a follow-up to the dynamic UID mapping changes on main (commit b436dbe) which introduced `${localEnv:HOST_UID:1000}` in build args.

## Test plan

- [ ] macOS (UID 501, GID 20): `podman build` succeeds without `groupadd` error
- [ ] WSL2 (UID 1000, GID 1000): build still works (no existing conflicts)
- [ ] Container user `claude` has correct UID/GID matching the host

🤖 Generated with [Claude Code](https://claude.com/claude-code)