### PR TITLE
fix: correct macOS Keychain extraction for Claude Code credentials

### DIFF
--- a/.devcontainer/scripts/initialize-host.sh
+++ b/.devcontainer/scripts/initialize-host.sh
@@ -97,7 +97,7 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     # Try known Keychain service names used by Claude Code.
     # Allow override via env var for non-standard installations.
     CLAUDE_TOKEN=""
-    KEYCHAIN_SERVICES=("claude.ai" "api.anthropic.com" "com.anthropic.claude-code" "claude-code")
+    KEYCHAIN_SERVICES=("Claude Code-credentials" "claude.ai" "api.anthropic.com" "com.anthropic.claude-code" "claude-code")
     if [[ -n "${CLAUDE_KEYCHAIN_SERVICE:-}" ]]; then
       KEYCHAIN_SERVICES=("${CLAUDE_KEYCHAIN_SERVICE}" "${KEYCHAIN_SERVICES[@]}")
     fi
@@ -118,14 +118,8 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 
     if [[ -n "${CLAUDE_TOKEN}" ]]; then
       # Write staging file. post-create.sh will move this into place.
-      # Format mirrors Claude Code's .credentials.json structure.
-      cat > "${CLAUDE_STAGED}" <<CEOF
-{
-  "claudeAiOauth": {
-    "token": "${CLAUDE_TOKEN}"
-  }
-}
-CEOF
+      # The keychain value is the complete credentials JSON — write it directly.
+      echo "${CLAUDE_TOKEN}" > "${CLAUDE_STAGED}"
       chmod 600 "${CLAUDE_STAGED}"
       echo "[initializeCommand] Exported Claude token to staging file"
     else


### PR DESCRIPTION
## Summary
- **Wrong service name**: Keychain lookup tried `claude.ai`, `api.anthropic.com`, etc. but the actual entry is `"Claude Code-credentials"`
- **Wrong credential format**: Script wrapped the extracted value in `{"claudeAiOauth":{"token":"..."}}` but the Keychain already stores the complete JSON (with `accessToken`, `refreshToken`, `expiresAt`, scopes) — now writes it directly

## Test plan
- [ ] Run `bash .devcontainer/scripts/initialize-host.sh` on macOS — should print "Found Claude token in Keychain (service: Claude Code-credentials)"
- [ ] Validate `~/.claude/.devcontainer-credentials.json` contains full OAuth JSON with `python3 -m json.tool`
- [ ] Rebuild devcontainer and verify `claude` authenticates inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)