### PR TITLE
feat: set default Claude Code model to Sonnet

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,5 +49,5 @@
       "Edit(scripts/wsl2/*)"
     ]
   },
-  "model": "opus"
+  "model": "sonnet"
 }


### PR DESCRIPTION
## Summary
- Changes the default Claude Code model from Opus to Sonnet in the template configuration
- Balances capability with faster inference for interactive development workflows

## Test plan
- Verify new projects instantiated from template use Sonnet as the default model
- Existing template users can override by changing `.claude/settings.json` locally