### PR TITLE
fix: guard destination directories in post-create.sh

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -17,6 +17,7 @@ if [[ -f /run/host-secrets/claude.json ]]; then
 fi
 
 if [[ -d /run/host-secrets/claude-dir ]]; then
+  mkdir -p "$HOME/.claude"
   if [[ -f "/run/host-secrets/claude-dir/.credentials.json" ]]; then
     cp "/run/host-secrets/claude-dir/.credentials.json" "$HOME/.claude/.credentials.json"
     chmod 600 "$HOME/.claude/.credentials.json"
@@ -36,6 +37,7 @@ if [[ -d /run/host-secrets/claude-dir ]]; then
 fi
 
 if [[ -d /run/host-secrets/gh ]]; then
+  mkdir -p "$HOME/.config/gh"
   cp -r /run/host-secrets/gh/. "$HOME/.config/gh/"
 
   # If the host exported a token-bearing staging file, use it as hosts.yml.


### PR DESCRIPTION
## Summary
- Add `mkdir -p "$HOME/.claude"` before copying Claude credentials
- Add `mkdir -p "$HOME/.config/gh"` before copying GitHub CLI config

**Why:** post-create.sh assumes these directories exist, but fresh container homes may not have them. Without the guards, `cp` fails and the script aborts (due to `set -euo pipefail`), leaving credentials uninitialized.

## Test plan
- Build container: `make build`
- Inside container: remove `~/.claude` and `~/.config/gh`, re-run post-create.sh
- Verify credentials are copied successfully and no errors occur
- Run `bash tests/container-checks.sh` to validate container environment