### PR TITLE
fix: remove redundant chmod +x on pre-commit hook

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -110,7 +110,6 @@ if [[ -d "${WORKSPACE_ROOT}/.git" && -f "${WORKSPACE_ROOT}/scripts/hooks/pre-com
   mkdir -p "${WORKSPACE_ROOT}/.git/hooks"
   rm -f "${WORKSPACE_ROOT}/.git/hooks/pre-commit"
   ln -s ../../scripts/hooks/pre-commit "${WORKSPACE_ROOT}/.git/hooks/pre-commit"
-  chmod +x "${WORKSPACE_ROOT}/scripts/hooks/pre-commit"
   echo "    Installed pre-commit hook (secret scanning)"
 fi
 


### PR DESCRIPTION
## Summary

- Removes the `chmod +x` call on `scripts/hooks/pre-commit` in `post-create.sh`
- The call fails when workspace files are owned by `nobody`/`nogroup` due to UID mismatch under `--userns=keep-id`
- The line was redundant: git already tracks the execute bit, so the file is always checked out as executable

## Test plan

- [ ] Rebuild devcontainer and confirm `post-create.sh` completes without errors
- [ ] Confirm `.git/hooks/pre-commit` symlink exists and is executable
- [ ] Run `git commit` to verify the secret-scanning hook still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)