### PR TITLE
feat: refresh macOS Keychain credentials without container rebuild

### DIFF
--- a/.devcontainer/scripts/credential-watcher.sh
+++ b/.devcontainer/scripts/credential-watcher.sh
@@ -27,6 +27,15 @@ copy_credentials() {
     echo "${LOG_PREFIX} Refreshed ~/.claude/.credentials.json"
   fi
 
+  # Keychain-exported staging file — written by scripts/macos-refresh-credentials.sh
+  # on the host when a token expires. Takes precedence over the filesystem copy
+  # because it reflects the latest Keychain state.
+  if [[ -s "${WATCH_DIR}/claude-dir/.devcontainer-credentials.json" ]]; then
+    cp "${WATCH_DIR}/claude-dir/.devcontainer-credentials.json" "$HOME/.claude/.credentials.json"
+    chmod 600 "$HOME/.claude/.credentials.json"
+    echo "${LOG_PREFIX} Refreshed ~/.claude/.credentials.json (Keychain export)"
+  fi
+
   if [[ -d "${WATCH_DIR}/claude-dir/sessions" ]]; then
     cp -r "${WATCH_DIR}/claude-dir/sessions" "$HOME/.claude/"
     echo "${LOG_PREFIX} Refreshed ~/.claude/sessions/"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup build status clean test-template help
+.PHONY: setup build status clean test-template refresh-credentials help
 
 IMAGE_TAG        ?= claude-code-devcontainer:latest
 
@@ -53,6 +53,10 @@ test-template:
 	test ! -f .claude/commands/init-project.md        && echo "  ✓ init-project removed"; \
 	test -f .claude/commands/improve-repo.md          && echo "  ✓ improve-repo preserved"; \
 	echo "Template test passed."
+
+## refresh-credentials   Re-extract macOS Keychain credentials into the running container (no rebuild needed)
+refresh-credentials:
+	@bash scripts/macos-refresh-credentials.sh
 
 ## help     Show available targets
 help:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Open this folder in VS Code and choose **"Reopen in Container"** when prompted, 
 | `make build` | Rebuild the image after `Containerfile` changes |
 | `make status` | Show runtime and container state |
 | `make clean` | Remove the image |
+| `make refresh-credentials` | Re-extract macOS Keychain credentials into the running container (no rebuild needed) |
 
 ---
 
@@ -129,6 +130,7 @@ A pre-commit hook scans both `.claude/memory/` and `.knowledge/` for secrets and
 ├── CLAUDE.md                         # Claude Code context (template version)
 ├── scripts/
 │   ├── detect-os.sh                  # Exports $DETECTED_OS (macos | wsl2)
+│   ├── macos-refresh-credentials.sh  # Re-extracts Keychain credentials mid-session (no rebuild)
 │   ├── hooks/
 │   │   └── pre-commit                # Secret scanner: blocks commits with credentials
 │   └── wsl2/
@@ -191,3 +193,10 @@ Your distro may not have systemd enabled. Run:
 systemctl --user status podman.socket
 ```
 If systemd is unavailable, `setup.sh` falls back to starting the socket directly — restart your WSL2 session and try again.
+
+**Claude token expired inside the container (macOS)**
+On macOS, Claude Code stores OAuth tokens in the system Keychain. If your token expires mid-session, re-authenticate on the host and then run:
+```bash
+make refresh-credentials
+```
+This re-extracts the new token from Keychain and propagates it into the running container via the credential watcher — no rebuild required. Check `/tmp/credential-watcher.log` inside the container to confirm the refresh was applied.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,31 @@ On macOS, both Claude Code and GitHub CLI may store OAuth tokens in the system K
 - **GitHub CLI**: `gh auth token` → staged to `~/.config/gh/.devcontainer-hosts.yml`
 - **Claude Code**: `security find-generic-password` → staged to `~/.claude/.devcontainer-credentials.json`
 
-`post-create.sh` detects these staging files and moves them into the container's writable credential locations, overriding any empty filesystem copies. Staging files are consumed (moved, not copied) so they don't persist.
+`post-create.sh` detects these staging files and copies them into the container's writable credential locations, overriding any empty filesystem copies.
+
+### Mid-session token refresh (macOS)
+
+`initializeCommand` runs only at container creation. If a Claude Code token expires while the container is running and the user re-authenticates on the host, the new token lands in the Keychain — not on the filesystem — so the bind mount at `/run/host-secrets/` sees no change and the `inotifywait` watcher is not triggered.
+
+`scripts/macos-refresh-credentials.sh` closes this gap. It re-runs the Keychain extraction on demand and writes updated staging files into `~/.claude/`. Because those files live inside the bind-mounted `~/.claude/` directory, `inotifywait` detects the write and `credential-watcher.sh` applies the new credentials within seconds — no rebuild needed.
+
+```
+User re-auths on host
+       │
+       ▼
+make refresh-credentials (runs on host)
+       │
+       ├── security find-generic-password → ~/.claude/.devcontainer-credentials.json
+       └── gh auth token                 → ~/.config/gh/.devcontainer-hosts.yml
+                       │
+                       ▼  (bind mount propagates)
+              /run/host-secrets/claude-dir/.devcontainer-credentials.json
+                       │
+                       ▼  (inotifywait fires)
+              credential-watcher.sh copies → ~/.claude/.credentials.json
+```
+
+The credential watcher checks `.devcontainer-credentials.json` after `.credentials.json` in `copy_credentials()`, so the Keychain-exported copy takes precedence over any stale filesystem copy.
 
 ## Nested Container Architecture
 

--- a/docs/SANDBOX-MODEL.md
+++ b/docs/SANDBOX-MODEL.md
@@ -69,7 +69,15 @@ This document describes the isolation boundaries for the Claude Code container e
 
 **Credential auto-refresh**: When the host rotates credentials (e.g., Claude auth token refresh), the `inotifywait`-based watcher detects the change and copies the updated file into `~/.claude/`. Log output goes to `/tmp/credential-watcher.log` inside the container.
 
-**Implication**: Container-side token refreshes are still lost on restart. Host-side refreshes are now picked up automatically.
+**macOS token expiry (mid-session)**: On macOS, Claude Code stores OAuth tokens in the system Keychain. If a token expires while the container is running, re-authenticating on the host updates the Keychain but not the filesystem — so the bind mount sees no change and the watcher is not triggered. To propagate new Keychain credentials into the running container without a rebuild, run on the host:
+
+```bash
+make refresh-credentials   # or: bash scripts/macos-refresh-credentials.sh
+```
+
+This re-extracts the token from Keychain, writes the updated staging file into `~/.claude/`, and the container-side watcher picks it up within a few seconds.
+
+**Implication**: Container-side token refreshes are still lost on restart. Host-side refreshes (filesystem or Keychain via `make refresh-credentials`) are picked up automatically without a rebuild.
 
 ## Extending the Sandbox
 

--- a/scripts/macos-refresh-credentials.sh
+++ b/scripts/macos-refresh-credentials.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Refresh Claude Code and GitHub credentials from the macOS Keychain without
+# rebuilding the container.
+#
+# Run this script ON THE HOST (not inside the container) after re-authenticating
+# Claude Code (e.g. after a token expiry). It re-extracts credentials from the
+# Keychain and writes them to the staging files that are bind-mounted into the
+# container. The container-side credential-watcher picks up the change
+# automatically via inotifywait — no rebuild required.
+#
+# Usage:
+#   bash scripts/macos-refresh-credentials.sh   # from the repo root on the host
+#   make refresh-credentials                     # equivalent shorthand
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "[refresh-credentials] This script is for macOS only." >&2
+  echo "                      On WSL2/Linux, credentials live on the filesystem" >&2
+  echo "                      and the container-side watcher handles them directly." >&2
+  exit 1
+fi
+
+echo "[refresh-credentials] Re-extracting credentials from macOS Keychain..."
+
+# ── Claude Code credentials ───────────────────────────────────────────────────
+CLAUDE_STAGED="${HOME}/.claude/.devcontainer-credentials.json"
+CLAUDE_CREDS="${HOME}/.claude/.credentials.json"
+CLAUDE_TOKEN=""
+
+KEYCHAIN_SERVICES=("Claude Code-credentials" "claude.ai" "api.anthropic.com" "com.anthropic.claude-code" "claude-code")
+if [[ -n "${CLAUDE_KEYCHAIN_SERVICE:-}" ]]; then
+  KEYCHAIN_SERVICES=("${CLAUDE_KEYCHAIN_SERVICE}" "${KEYCHAIN_SERVICES[@]}")
+fi
+
+for SERVICE in "${KEYCHAIN_SERVICES[@]}"; do
+  CLAUDE_TOKEN="$(security find-generic-password -s "${SERVICE}" -w 2>/dev/null || true)"
+  if [[ -n "${CLAUDE_TOKEN}" ]]; then
+    echo "[refresh-credentials] Found Claude token in Keychain (service: ${SERVICE})"
+    break
+  fi
+  CLAUDE_TOKEN="$(security find-internet-password -s "${SERVICE}" -w 2>/dev/null || true)"
+  if [[ -n "${CLAUDE_TOKEN}" ]]; then
+    echo "[refresh-credentials] Found Claude token in Keychain (internet-password: ${SERVICE})"
+    break
+  fi
+done
+
+if [[ -n "${CLAUDE_TOKEN}" ]]; then
+  # Write to staging file — the bind mount at /run/host-secrets/claude-dir/
+  # makes this immediately visible inside the container.
+  echo "${CLAUDE_TOKEN}" > "${CLAUDE_STAGED}"
+  chmod 600 "${CLAUDE_STAGED}"
+  echo "[refresh-credentials] Updated ${CLAUDE_STAGED}"
+
+  # Also update the filesystem credentials file so future container restarts
+  # pick up the latest token even if Keychain extraction is skipped.
+  echo "${CLAUDE_TOKEN}" > "${CLAUDE_CREDS}"
+  chmod 600 "${CLAUDE_CREDS}"
+  echo "[refresh-credentials] Updated ${CLAUDE_CREDS}"
+else
+  # No Keychain token found — check if filesystem credentials exist instead.
+  if [[ -s "${CLAUDE_CREDS}" ]] && grep -q '"token"' "${CLAUDE_CREDS}" 2>/dev/null; then
+    echo "[refresh-credentials] No Keychain token found; filesystem credentials exist and will be used."
+  else
+    echo "[refresh-credentials] WARNING: No Claude token found in Keychain or on filesystem." >&2
+    echo "                      Run 'claude auth login' on the host to authenticate." >&2
+  fi
+fi
+
+# ── GitHub CLI credentials ────────────────────────────────────────────────────
+GH_STAGED="${HOME}/.config/gh/.devcontainer-hosts.yml"
+
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  GH_TOKEN="$(gh auth token 2>/dev/null || true)"
+  if [[ -n "${GH_TOKEN}" ]]; then
+    GH_USER="$(gh api user --jq .login 2>/dev/null || echo "")"
+    GH_PROTO="$(gh config get git_protocol 2>/dev/null || echo "https")"
+    cat > "${GH_STAGED}" <<YEOF
+github.com:
+    oauth_token: ${GH_TOKEN}
+    git_protocol: ${GH_PROTO}
+    user: ${GH_USER}
+YEOF
+    chmod 600 "${GH_STAGED}"
+    echo "[refresh-credentials] Updated ${GH_STAGED}"
+  else
+    echo "[refresh-credentials] gh authenticated but token extraction failed — skipping"
+  fi
+else
+  echo "[refresh-credentials] gh not installed or not authenticated — skipping"
+fi
+
+echo ""
+echo "[refresh-credentials] Done. The container-side credential-watcher will apply"
+echo "                      the updated credentials automatically within a few seconds."
+echo "                      Check: cat /tmp/credential-watcher.log  (inside the container)"


### PR DESCRIPTION
## Summary

- **Root cause**: On macOS, Claude Code OAuth tokens live in the system Keychain. When a token expires mid-session and the user re-authenticates on the host, the new token updates the Keychain but not the filesystem — so the bind-mounted `/run/host-secrets/` directory sees no change and the container-side `inotifywait` watcher never fires. The container stays stuck with the expired token, requiring a full rebuild.

- **`scripts/macos-refresh-credentials.sh`** (new): host-side script that re-extracts Claude Code and GitHub CLI tokens from the Keychain using the same service-name sweep as `initialize-host.sh`. Writes updated staging files (`~/.claude/.devcontainer-credentials.json`, `~/.config/gh/.devcontainer-hosts.yml`) into the bind-mounted directories so the container sees them immediately.

- **`credential-watcher.sh`** (updated): `copy_credentials()` now also handles `.devcontainer-credentials.json`. When the host refresh script writes a new staging file, `inotifywait` fires and the watcher copies the fresh token to `~/.claude/.credentials.json` — no rebuild required.

- **`Makefile`**: adds `make refresh-credentials` shorthand for the host-side script.

- **Docs**: `ARCHITECTURE.md`, `SANDBOX-MODEL.md`, and `README.md` updated with the mid-session expiry scenario, the new flow diagram, and a troubleshooting entry.

## Workflow after this change

```bash
# Token expired — re-authenticate on the host:
claude auth login

# Propagate to the running container (no rebuild):
make refresh-credentials

# Confirm inside the container:
cat /tmp/credential-watcher.log
# → [credential-watcher] Refreshed ~/.claude/.credentials.json (Keychain export)
```

## Test plan

- [ ] Re-authenticate Claude Code on a macOS host
- [ ] Run `make refresh-credentials` — confirm it finds the Keychain token and reports success
- [ ] Inside the container, check `/tmp/credential-watcher.log` for the refresh event within ~2 seconds
- [ ] Confirm `~/.claude/.credentials.json` in the container contains the new token
- [ ] Confirm `claude` commands work without restarting or rebuilding the container
- [ ] On WSL2/Linux, run `make refresh-credentials` — confirm it exits with the "macOS only" message and non-zero status

🤖 Generated with [Claude Code](https://claude.com/claude-code)